### PR TITLE
Make version string compatible with Emacs < 24.4

### DIFF
--- a/company.el
+++ b/company.el
@@ -5,7 +5,7 @@
 ;; Author: Nikolaj Schumacher
 ;; Maintainer: Dmitry Gutov <dgutov@yandex.ru>
 ;; URL: http://company-mode.github.io/
-;; Version: 0.8.0-snapshot
+;; Version: 0.8.0-cvs
 ;; Keywords: abbrev, convenience, matching
 ;; Package-Requires: ((emacs "24.1"))
 


### PR DESCRIPTION
`version-to-list` doesn't have snapshot support before 24.4. The `-cvs` suffix
is the closest we can get there and it will be interpreted as a snapshot version
on 24.4+ anyways.
