### PR TITLE
Assign a face for the tooltip search string

### DIFF
--- a/company.el
+++ b/company.el
@@ -117,6 +117,10 @@ buffer-local wherever it is set."
     (t (:background "green")))
   "Face used for the selection in the tooltip.")
 
+(defface company-tooltip-search
+  '((default :inherit company-tooltip-selection))
+  "Face used for the search string in the tooltip.")
+
 (defface company-tooltip-mouse
   '((default :inherit highlight))
   "Face used for the tooltip item under the mouse.")
@@ -2156,7 +2160,7 @@ If SHOW-VERSION is non-nil, show the version in the echo area."
                              (length company-prefix)))
           (let ((beg (+ margin (match-beginning 0)))
                 (end (+ margin (match-end 0))))
-            (add-text-properties beg end '(face company-tooltip-selection)
+            (add-text-properties beg end '(face company-tooltip-search)
                                  line)
             (when (< beg common)
               (add-text-properties beg common


### PR DESCRIPTION
This change makes the search string in the company tooltip configurable.  It inherits from the face it replaces, so the default appearance remains the same.

I think of company-tooltip-selection much like I might think hl-line or hovering over a button, whereas company-tooltip-search is more like isearch.  They should be configurable separately.
