### PR TITLE
Use read-kbd-macro instead of kbd as a function.

### DIFF
--- a/company.el
+++ b/company.el
@@ -627,7 +627,7 @@ asynchronous call into synchronous.")
     (define-key keymap "\C-s" 'company-search-candidates)
     (define-key keymap "\C-\M-s" 'company-filter-candidates)
     (dotimes (i 10)
-      (define-key keymap (kbd (format "M-%d" i)) 'company-complete-number))
+      (define-key keymap (read-kbd-macro (format "M-%d" i)) 'company-complete-number))
      keymap)
   "Keymap that is enabled during an active completion.")
 


### PR DESCRIPTION
In Emacs 24.1 and 24.2, kbd was a macro and not a function,
so that a call like (kbd (format ...)) would fail. Use
read-kbd-macro instead, which works for all Emacsen in 24.x.
