### PR TITLE
Improve Clang completion performance

### DIFF
--- a/company-clang.el
+++ b/company-clang.el
@@ -180,14 +180,20 @@ or automatically through a custom `company-clang-prefix-guesser'."
         (setq buffer-read-only t)
         (goto-char (point-min))))))
 
+(defun company-clang--run-clang-command (buf prefix args)
+  (if (executable-find "grep")
+      (let* ((join-args (mapconcat 'identity args " "))
+             (command (format "%s %s | grep -i \": %s\"" company-clang-executable join-args prefix)))
+        (start-process-shell-command "company-clang" buf command))
+    (apply #'start-process "company-clang" buf company-clang-executable args)))
+
 (defun company-clang--start-process (prefix callback &rest args)
   (let ((objc (derived-mode-p 'objc-mode))
         (buf (get-buffer-create "*clang-output*")))
     (with-current-buffer buf (erase-buffer))
     (if (get-buffer-process buf)
         (funcall callback nil)
-      (let ((process (apply #'start-process "company-clang" buf
-                            company-clang-executable args)))
+      (let ((process (company-clang--run-clang-command buf prefix args)))
         (set-process-sentinel
          process
          (lambda (proc status)


### PR DESCRIPTION
On systems with `grep` installed this significantly improves performance in scenarios with little context by filtering the results by the prefix. It does this because clang only takes `0.3`s or so to create the completion but it takes a long time for Emacs  to read that into a buffer, this just trims down the size before it enters the buffer and minimizes that hit. 

This fixes #225 see that issue for discussion of problem and some timings.

On systems that don't have `grep` (like Windows :disappointed: ) it falls back on running clang directly.
Expected number of users hitting this code path is zero because it's very hard to install Clang on Windows and nobody does it, and who else doesn't have grep? I did test it though.

This change improves performance for global scope completion in a small project from around 20s (the async timeout means the results are ignored when they do arrive) down to a fraction of a second for a 2 character prefix. From a qualitative perspective it feels SOOO much faster all around. 