### PR TITLE
Define customize group for company-bbdb

### DIFF
--- a/company-bbdb.el
+++ b/company-bbdb.el
@@ -27,6 +27,10 @@
 (declare-function bbdb-dwim-mail "bbdb-com")
 (declare-function bbdb-search "bbdb-com")
 
+(defgroup company-bbdb nil
+  "Completion back-end for `bbdb'"
+  :group 'company)
+
 (defcustom company-bbdb-modes '(message-mode)
   "Major modes in which `company-bbdb' may complete."
   :type '(repeat (symbol :tag "Major mode"))


### PR DESCRIPTION
The `company-bbdb` backend does not define a customize group.

I defined a `company-bbdb` group with parent `company`

[![24pullrequests](http://24pullrequests.com/assets/logo-625222452ffc0d57272decb6f851a7fe.png)](http://24pullrequests.com)

Best,
Markus
