### PR TITLE
company-kill-ring

### DIFF
--- a/company-kill-ring.el
+++ b/company-kill-ring.el
@@ -1,0 +1,49 @@
+;;; company-kill-ring.el --- company-mode completion back-end for the kill-ring
+
+;; Copyright (C) 2009-2011  Free Software Foundation, Inc.
+
+;; Author: Nikolaj Schumacher
+
+;; This file is part of GNU Emacs.
+
+;; GNU Emacs is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+
+
+;;; Commentary:
+;;
+
+;;; Code:
+
+(require 'company)
+(require 'cl-lib)
+
+;;;###autoload
+(defun company-kill-ring (command &optional arg &rest ignored)
+  "`company-mode' completion for the kill-ring."
+  (interactive (list 'interactive))
+  (cl-case command
+    (interactive (company-begin-backend 'company-kill-ring))
+    (prefix "")
+    (candidates (mapcar #'substring-no-properties kill-ring))))
+
+;;;###autoload
+(defun company-kill-ring-search ()
+  "Open a `company-mode' popup with the `kill-ring' for search and selection."
+  (interactive)
+  (let ((company-backends '(company-kill-ring)))
+    (company-manual-begin)
+    (company-filter-candidates)))
+
+(provide 'company-kill-ring)
+;;; company-kill-ring.el ends here


### PR DESCRIPTION
@dgutov first off, much respect for your job in maintaining and enhancing `company-mode`.

i was wondering if it might be easy enough to add kill-ring support for company, in the spirit of `browse-kill-ring` or `popup-kill-ring`. this is my first attempt at creating a company back-end but it works pretty well so far.

i doubt any user would want to add `company-kill-ring` to `company-backends` in their configurations, but i thought it would be useful to include a defun to pop open a company instance with the kill-ring for search and selection, hence the other autoloaded defun.

one obvious issue i'm seeing is an error when trying to search by a word nested fairly deep in a killed string:

```
company-call-frontends: Company: Front-end company-pseudo-tooltip-unless-just-one-frontend error "Args out of range: 127, 132" on command update
```

i'm curious if you feel like this would be a worthwhile core module, and if you don't think so, i can create my own extension package. either way, i'd appreciate your feedback on what might make this work better. thanks!