### PR TITLE
company-etags-find-table: fix fallback tags file expansion

### DIFF
--- a/company-etags.el
+++ b/company-etags.el
@@ -51,11 +51,11 @@ buffer automatically."
 (defvar-local company-etags-buffer-table 'unknown)
 
 (defun company-etags-find-table ()
-  (let ((file (locate-dominating-file (or buffer-file-name
-                                          default-directory)
-                                      "TAGS")))
-    (when (and file (file-regular-p file))
-      (list (expand-file-name file)))))
+  (let ((dir (locate-dominating-file (or buffer-file-name
+                                         default-directory)
+                                     "TAGS")))
+    (when dir
+      (list (expand-file-name "TAGS" dir)))))
 
 (defun company-etags-buffer-table ()
   (or (and company-etags-use-main-table-list tags-table-list)

--- a/company-etags.el
+++ b/company-etags.el
@@ -51,11 +51,13 @@ buffer automatically."
 (defvar-local company-etags-buffer-table 'unknown)
 
 (defun company-etags-find-table ()
-  (let ((dir (locate-dominating-file (or buffer-file-name
-                                         default-directory)
-                                     "TAGS")))
-    (when dir
-      (list (expand-file-name "TAGS" dir)))))
+  (let ((file (expand-file-name
+               "TAGS"
+               (locate-dominating-file (or buffer-file-name
+                                           default-directory)
+                                       "TAGS"))))
+    (when (and file (file-regular-p file))
+      (list file))))
 
 (defun company-etags-buffer-table ()
   (or (and company-etags-use-main-table-list tags-table-list)


### PR DESCRIPTION
locate-dominating-file returns a directory or nil, so the `(file-regular-p file)` was always `nil`.  Also, the call to `expand-file-name` seemed weird --- the dir should be the optional 2nd argument, not the first.

With the fix, the function should actually return an absolute path to any "TAGS" file, as originally intended.