### PR TITLE
company-etags: simpler and less intrusive table building

### DIFF
--- a/company-etags.el
+++ b/company-etags.el
@@ -70,9 +70,7 @@ buffer automatically."
         (completion-ignore-case company-etags-ignore-case))
     (and (or tags-file-name tags-table-list)
          (fboundp 'tags-completion-table)
-         (save-excursion
-           (visit-tags-table-buffer)
-           (all-completions prefix (tags-completion-table))))))
+         (all-completions prefix (tags-completion-table)))))
 
 ;;;###autoload
 (defun company-etags (command &optional arg &rest ignored)


### PR DESCRIPTION
I am trying to clean up all my etags addons and workarounds (it's not pretty..), and this was a blocker: It seems that `save-excursion` and `visit-tags-table-buffer` are not necessary here --- `tags-completion-table` does that dance properly itself.  But the current code *does* introduce problems when there are different completion tables per buffer: `v-t-t-b` selects a tags buffer itself, and when `t-c-t` tests if there is a buffer-local cached value for the completion table, it does *not* do so in the original buffer where we wanted to complete, but in the tags buffer.

Replacing that by a plain call to get the completions is simpler, and it avoids this and potential other problems.