### PR TITLE
Allow advising company-dabbrev(-code)? regex generation

### DIFF
--- a/company-dabbrev-code.el
+++ b/company-dabbrev-code.el
@@ -69,7 +69,7 @@ also `company-dabbrev-code-time-limit'."
   "Non-nil to ignore case when collecting completion candidates."
   :type 'boolean)
 
-(defsubst company-dabbrev-code--make-regexp (prefix)
+(defun company-dabbrev-code--make-regexp (prefix)
   (concat "\\_<" (if (equal prefix "")
                      "\\([a-zA-Z]\\|\\s_\\)"
                    (regexp-quote prefix))

--- a/company-dabbrev.el
+++ b/company-dabbrev.el
@@ -91,7 +91,7 @@ This variable affects both `company-dabbrev' and `company-dabbrev-code'."
               (> (float-time (time-since ,start)) ,limit)
               (throw 'done 'company-time-out))))))
 
-(defsubst company-dabbrev--make-regexp (prefix)
+(defun company-dabbrev--make-regexp (prefix)
   (concat "\\<" (if (equal prefix "")
               company-dabbrev-char-regexp
             (regexp-quote prefix))


### PR DESCRIPTION
This should allow me to write an advice that implements fuzzy matching for `company-dabbrev` and `company-dabbrev-code`. I doubt the extra function-call overhead will cost you very much relative to the real work done by the respective backends.