### PR TITLE
company-capf: Allow custom prefix function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+* `company-capf` accepts `:company-prefix-length` property function.
 * New face `company-tooltip-annotation-selection`, used for the annotation in
   the selected tooltip line.
 * `company-clang-objc-templatify` has been renamed to

--- a/company-capf.el
+++ b/company-capf.el
@@ -72,9 +72,15 @@
     (`prefix
      (let ((res (company--capf-data)))
        (when res
-         (if (> (nth 2 res) (point))
-             'stop
-           (buffer-substring-no-properties (nth 1 res) (point))))))
+         (let* ((f (plist-get (nthcdr 4 res) :company-prefix-length))
+                (beg (nth 1 res))
+                (end (nth 2 res))
+                (length (and f (funcall f beg (point))))
+                (prefix (buffer-substring-no-properties beg (point))))
+           (cond
+            ((> end (point)) 'stop)
+            (length (cons prefix length))
+            (t prefix))))))
     (`candidates
      (let ((res (company--capf-data)))
        (when res


### PR DESCRIPTION
There is currently no way to have custom logic in the `prefix` command for `company-capf`, such as when you want to return a cons-cell instead of a string. This let's you specify a prefix function using `:company-prefix` in the capf-function.