### PR TITLE
Fix bbdb completion for multi-recipient messages

### DIFF
--- a/company-bbdb.el
+++ b/company-bbdb.el
@@ -1,6 +1,6 @@
 ;;; company-bbdb.el --- company-mode completion backend for BBDB in message-mode
 
-;; Copyright (C) 2013-2014  Free Software Foundation, Inc.
+;; Copyright (C) 2013-2014, 2016  Free Software Foundation, Inc.
 
 ;; Author: Jan Tatarik <jan.tatarik@gmail.com>
 
@@ -50,7 +50,7 @@
     (interactive (company-begin-backend 'company-bbdb))
     (prefix (and (memq major-mode company-bbdb-modes)
                  (featurep 'bbdb-com)
-                 (looking-back "^\\(To\\|Cc\\|Bcc\\): *\\(.*\\)"
+                 (looking-back "^\\(To\\|Cc\\|Bcc\\): *.*?\\([^,; ]*\\)"
                                (line-beginning-position))
                  (match-string-no-properties 2)))
     (candidates (company-bbdb--candidates arg))


### PR DESCRIPTION
Trigger completion for the last incomplete recipient address only,
instead of the whole recipient list.