### PR TITLE
Option to have tempo expand tags after completion.

### DIFF
--- a/company-tempo.el
+++ b/company-tempo.el
@@ -60,12 +60,11 @@
   "`company-mode' completion backend for tempo."
   (interactive (list 'interactive))
   (cl-case command
-    (interactive (company-begin-backend 'company-tempo
-                                        'company-tempo-insert))
+    (interactive (company-begin-backend 'company-tempo))
     (prefix (or (car (tempo-find-match-string tempo-match-finder)) ""))
     (candidates (all-completions arg (tempo-build-collection)))
     (meta (company-tempo-meta arg))
-    (post-completion (when company-tempo-expand (tempo-expand-if-complete)))
+    (post-completion (when company-tempo-expand (company-tempo-insert arg)))
     (sorted t)))
 
 (provide 'company-tempo)

--- a/company-tempo.el
+++ b/company-tempo.el
@@ -29,6 +29,15 @@
 (require 'cl-lib)
 (require 'tempo)
 
+(defgroup company-tempo nil
+  "Tempo completion backend."
+  :group 'company)
+
+(defcustom company-tempo-expand nil
+  "Whether to expand a tempo tag after completion."
+  :type '(choice (const :tag "Off" nil)
+                 (const :tag "On" t)))
+
 (defsubst company-tempo-lookup (match)
   (cdr (assoc match (tempo-build-collection))))
 
@@ -56,6 +65,7 @@
     (prefix (or (car (tempo-find-match-string tempo-match-finder)) ""))
     (candidates (all-completions arg (tempo-build-collection)))
     (meta (company-tempo-meta arg))
+    (post-completion (when company-tempo-expand (tempo-expand-if-complete)))
     (sorted t)))
 
 (provide 'company-tempo)


### PR DESCRIPTION
I've added a post-completion call to tempo-expand-if-complete so that tempo tags expand. company-tempo-expand seems like it's supposed to take care of that but it has never worked for me.