### PR TITLE
add explicit option for which standard to use with company clang and make it buffer local

### DIFF
--- a/company-clang.el
+++ b/company-clang.el
@@ -53,6 +53,16 @@ Prefix files (-include ...) can be selected with `company-clang-set-prefix'
 or automatically through a custom `company-clang-prefix-guesser'."
   :type '(repeat (string :tag "Argument")))
 
+(defcustom company-clang-std nil
+  "The language standard to use in Clang.
+
+The value of this variable is either a string denoting a language
+standard, or nil, to use the default standard.  When non-nil,
+pass the language standard via the `-std' option."
+  :type '(choice (const :tag "Default standard" nil)
+                 (string :tag "Language standard")))
+(make-variable-buffer-local 'company-clang-std)
+
 (defcustom company-clang-prefix-guesser 'company-clang-guess-prefix
   "A function to determine the prefix file for the current buffer."
   :type '(function :tag "Guesser function" nil))
@@ -245,6 +255,8 @@ or automatically through a custom `company-clang-prefix-guesser'."
           (unless (company-clang--auto-save-p)
             (list "-x" (company-clang--lang-option)))
           company-clang-arguments
+          (when company-clang-std
+            (list (concat "-std=" company-clang-std)))
           (when (stringp company-clang--prefix)
             (list "-include" (expand-file-name company-clang--prefix)))
           (list "-Xclang" (format "-code-completion-at=%s"


### PR DESCRIPTION
Presently company clang is somewhat clunky when it comes to different versions of the standard. in order to make c++11/14 completions work, some variant of the following must be used
```
(setq company-clang-arguments (list "-std=c++14"))
```
This is unfortunate for a few reasons.

1. Figuring this our requires some decent looking into the code of company-clang, which is not preferable.
2. Once the correct variable to edit is found, the fact that it must be a list is not obvious
3. If editing files of multiple types for which different standards are important (such as having a .c and a .cpp file open at the same time) this setup causes problems.

The solution I created is simply to 
a. Create an explicit option for the std to use
b. make it buffer local in order to not have multiple file types open wreck havoc.

With the new code, the way to set the standard would be to put the following in a hook
`(setq company-clang-std "c++14")`