### PR TITLE
Bind non-essential to prevent tramp error

### DIFF
--- a/company-capf.el
+++ b/company-capf.el
@@ -79,7 +79,8 @@
             (length (cons prefix length))
             (t prefix))))))
     (`candidates
-     (let ((res (company--capf-data)))
+     (let* ((non-essential t)
+            (res (company--capf-data)))
        (when res
          (let* ((table (nth 3 res))
                 (pred (plist-get (nthcdr 4 res) :predicate))


### PR DESCRIPTION
I use `company-capf` in `eshell`. An error is raised when completing _Tramp_ filenames like 
`
cd /scp:`
`
->
```
Debugger entered--Lisp error: (error "Company: backend company-capf error \"Host name must not match method \"scp\"\" with args (candidates /scp:)")
```
See discussion here:

http://lists.gnu.org/archive/html/tramp-devel/2016-03/msg00005.html

