### PR TITLE
Fixed lighter for grouped backends

### DIFF
--- a/company.el
+++ b/company.el
@@ -1096,7 +1096,8 @@ can retrieve meta-data for them."
 
 (defun company--group-lighter (candidate base)
   (let ((backend (or (get-text-property 0 'company-backend candidate)
-                     (car company-backend))))
+                     (cl-some (lambda (x) (and (not (keywordp x)) x))
+                              company-backend))))
     (when (and backend (symbolp backend))
       (let ((name (replace-regexp-in-string "company-\\|-company" ""
                                             (symbol-name backend))))


### PR DESCRIPTION
Fixed issue where if the car of company-backend was a keyword (eg :sorted) the lighter would display that instead of the correct backend. (I believe this necessary due to the "small perf optimization" in company--multi-backend-adapter-candidates