### PR TITLE
fix company-etags doesn't support for lua-mode

### DIFF
--- a/company-etags.el
+++ b/company-etags.el
@@ -55,7 +55,7 @@ Set it to t or to a list of major modes."
   :package-version '(company . "0.9.0"))
 
 (defvar company-etags-modes '(prog-mode c-mode objc-mode c++-mode java-mode
-                              jde-mode pascal-mode perl-mode python-mode))
+                              jde-mode pascal-mode perl-mode python-mode lua-mode))
 
 (defvar-local company-etags-buffer-table 'unknown)
 


### PR DESCRIPTION
fixed:  https://github.com/company-mode/company-mode/issues/493

Because `lua-mode` is 

```
(define-derived-mode lua-mode lua--prog-mode "Lua"
```

And

When using `(apply #'derived-mode-p company-etags-modes)` in lua-mode, it will fails.

