### PR TITLE
Add option to company-yasnippet whether candidates are merged with other backends

### DIFF
--- a/company-yasnippet.el
+++ b/company-yasnippet.el
@@ -35,6 +35,13 @@
 (declare-function yas--template-expand-env "yasnippet")
 (declare-function yas--warning "yasnippet")
 
+(defgroup company-yasnippet nil
+  "Completion backend for yasnippet")
+(defcustom company-yasnippet-merge-candidates t
+  "Whether completion candidates should merge with other backends"
+  :tag "Whether completion candidates should merge with other backends"
+  :group 'company-yasnippet)
+
 (defun company-yasnippet--key-prefixes ()
   ;; Mostly copied from `yas--templates-for-key-at-point'.
   (defvar yas-key-syntaxes)
@@ -86,7 +93,8 @@
               (maphash
                (lambda (name template)
                  (push
-                  (propertize key
+                  (propertize (or (and company-yasnippet-merge-candidates key)
+                                  (concat key " "))
                               'yas-annotation name
                               'yas-template template
                               'yas-prefix-offset (- (length key-prefix)


### PR DESCRIPTION
Many people are using this:

    ;; https://github.com/syl20bnr/spacemacs/pull/179
    (defvar company-mode/enable-yas t
      "Enable yasnippet for all backends.")

    (defun company-mode/backend-with-yas (backend)
      (if (or (not company-mode/enable-yas)
              (and (listp backend) (member 'company-yasnippet backend)))
          backend
        (append (if (consp backend) backend (list backend))
                '(:with company-yasnippet))))

    (setq company-backends (mapcar #'company-mode/backend-with-yas company-backends))

I think there should be a choice whether the yas completion should replace the original completion.