### PR TITLE
Add support for auto-complete like behavior

### DIFF
--- a/company.el
+++ b/company.el
@@ -2859,20 +2859,20 @@ Returns a negative number if the tooltip should be displayed above point."
 Delay is determined by `company-tooltip-idle-delay'."
   (cl-case command
     (pre-command
-     (company-pseudo-tooltip-frontend command)
+     (company-pseudo-tooltip-unless-just-one-frontend command)
      (when company-tooltip-timer
        (cancel-timer company-tooltip-timer)
        (setq company-tooltip-timer nil)))
     (post-command
      (if (or company-tooltip-timer
              (overlayp company-pseudo-tooltip-overlay))
-         (company-pseudo-tooltip-frontend command)
+         (company-pseudo-tooltip-unless-just-one-frontend command)
        (setq company-tooltip-timer
              (run-with-timer company-tooltip-idle-delay nil
                              'company-pseudo-tooltip-frontend-with-delay
                              'post-command))))
     (t
-     (company-pseudo-tooltip-frontend command))))
+     (company-pseudo-tooltip-unless-just-one-frontend command))))
 
 ;;; overlay ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/company.el
+++ b/company.el
@@ -2074,7 +2074,7 @@ With ARG, move by that many elements."
                  (eq old-tick (buffer-chars-modified-tick)))
         (company-complete-common))))))
 
-(defun company-complete-selection-or-select-next-if-tooltip-visible ()
+(defun company-select-next-if-tooltip-visible-or-complete-selection ()
   "This should be used with `company-pseudo-tooltip-frontend-with-delay'.
 Insert selection if only preview is showing or only one candidate, or select the next candidate."
   (interactive)

--- a/company.el
+++ b/company.el
@@ -2843,18 +2843,22 @@ Returns a negative number if the tooltip should be displayed above point."
 (defun company-pseudo-tooltip-frontend-with-delay (command)
   "`compandy-pseudo-tooltip-frontend', but shown after a delay.
 Delay is determined by `company-tooltip-idle-delay'."
-  (when (and (eq command 'pre-command) company-tooltip-timer)
-    (cancel-timer company-tooltip-timer)
-    (setq company-tooltip-timer nil))
-  (unless (and (eq command 'post-command)
-               (company--show-inline-p))
-    (if (or (not (eq command 'post-command))
-            (overlayp company-pseudo-tooltip-overlay))
-        (company-pseudo-tooltip-frontend command)
-      (setq company-tooltip-timer
-            (run-with-timer company-tooltip-idle-delay nil
-                            'company-pseudo-tooltip-frontend
-                            'post-command)))))
+  (cl-case command
+    (pre-command
+     (company-pseudo-tooltip-frontend command)
+     (when company-tooltip-timer
+       (cancel-timer company-tooltip-timer)
+       (setq company-tooltip-timer nil)))
+    (post-command
+     (if (or company-tooltip-timer
+             (overlayp company-pseudo-tooltip-overlay))
+         (company-pseudo-tooltip-frontend command)
+       (setq company-tooltip-timer
+             (run-with-timer company-tooltip-idle-delay nil
+                             'company-pseudo-tooltip-frontend-with-delay
+                             'post-command))))
+    (t
+     (company-pseudo-tooltip-frontend command))))
 
 ;;; overlay ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/company.el
+++ b/company.el
@@ -2075,8 +2075,10 @@ With ARG, move by that many elements."
         (company-complete-common))))))
 
 (defun company-select-next-if-tooltip-visible-or-complete-selection ()
-  "This should be used with `company-pseudo-tooltip-frontend-with-delay'.
-Insert selection if only preview is showing or only one candidate, or select the next candidate."
+  "Insert selection if only preview is showing or only one candidate, or select the next candidate.
+When used with with `company-pseudo-tooltip-frontend-with-delay',
+if tooltip is not visible or only one candidate, complete selection,
+else, select-active-regions the next candidate."
   (interactive)
   (if (and (company-tooltip-visible) (> company-candidates-length 1))
       (call-interactively 'company-select-next)

--- a/company.el
+++ b/company.el
@@ -2079,7 +2079,7 @@ With ARG, move by that many elements."
 Insert selection if only preview is showing or only one candidate,
 otherwise select the next candidate."
   (interactive)
-  (if (and (company-tooltip-visible) (> company-candidates-length 1))
+  (if (and (company-tooltip-visible-p) (> company-candidates-length 1))
       (call-interactively 'company-select-next)
     (call-interactively 'company-complete-selection)))
 
@@ -2947,7 +2947,7 @@ Delay is determined by `company-tooltip-idle-delay'."
        (or (eq (company-call-backend 'ignore-case) 'keep-prefix)
            (string-prefix-p company-prefix company-common))))
 
-(defun company-tooltip-visible ()
+(defun company-tooltip-visible-p ()
   "Returns whether the tooltip is visible."
   (when (overlayp company-pseudo-tooltip-overlay)
     (not (overlay-get company-pseudo-tooltip-overlay 'invisible))))

--- a/company.el
+++ b/company.el
@@ -2865,7 +2865,12 @@ Delay is determined by `company-tooltip-idle-delay'."
     (post-command
      (if (or company-tooltip-timer
              (overlayp company-pseudo-tooltip-overlay))
-         (company-pseudo-tooltip-unless-just-one-frontend command)
+         (if (not (memq 'company-preview-frontend company-frontends))
+             (company-pseudo-tooltip-unless-just-one-frontend command)
+           (progn
+             (company-preview-frontend 'pre-command)
+             (company-pseudo-tooltip-unless-just-one-frontend command)
+             (company-preview-frontend 'post-command)))
        (setq company-tooltip-timer
              (run-with-timer company-tooltip-idle-delay nil
                              'company-pseudo-tooltip-unless-just-one-frontend-with-delay

--- a/company.el
+++ b/company.el
@@ -2867,10 +2867,9 @@ Delay is determined by `company-tooltip-idle-delay'."
              (overlayp company-pseudo-tooltip-overlay))
          (if (not (memq 'company-preview-frontend company-frontends))
              (company-pseudo-tooltip-unless-just-one-frontend command)
-           (progn
-             (company-preview-frontend 'pre-command)
-             (company-pseudo-tooltip-unless-just-one-frontend command)
-             (company-preview-frontend 'post-command)))
+           (company-preview-frontend 'pre-command)
+           (company-pseudo-tooltip-unless-just-one-frontend command)
+           (company-preview-frontend 'post-command))
        (setq company-tooltip-timer
              (run-with-timer company-tooltip-idle-delay nil
                              'company-pseudo-tooltip-unless-just-one-frontend-with-delay

--- a/company.el
+++ b/company.el
@@ -2075,10 +2075,9 @@ With ARG, move by that many elements."
         (company-complete-common))))))
 
 (defun company-select-next-if-tooltip-visible-or-complete-selection ()
-  "Insert selection if only preview is showing or only one candidate, or select the next candidate.
-When used with with `company-pseudo-tooltip-unless-just-one-frontend-with-delay',
-if tooltip is not visible or only one candidate, complete selection,
-else, select-active-regions the next candidate."
+  "Insert selection if appropriate, or select the next candidate.
+Insert selection if only preview is showing or only one candidate,
+otherwise select the next candidate."
   (interactive)
   (if (and (company-tooltip-visible) (> company-candidates-length 1))
       (call-interactively 'company-select-next)

--- a/company.el
+++ b/company.el
@@ -188,9 +188,9 @@ buffer-local wherever it is set."
   (let ((value (delete-dups (copy-sequence value))))
     (and (or (and (memq 'company-pseudo-tooltip-unless-just-one-frontend value)
                   (memq 'company-pseudo-tooltip-frontend value))
-             (and (memq 'company-pseudo-tooltip-frontend-with-delay value)
+             (and (memq 'company-pseudo-tooltip-unless-just-one-frontend-with-delay value)
                   (memq 'company-pseudo-tooltip-frontend value))
-             (and (memq 'company-pseudo-tooltip-frontend-with-delay value)
+             (and (memq 'company-pseudo-tooltip-unless-just-one-frontend-with-delay value)
                   (memq 'company-pseudo-tooltip-unless-just-one-frontend value)))
          (error "Pseudo tooltip frontend cannot be used more than once"))
     (and (memq 'company-preview-if-just-one-frontend value)
@@ -238,7 +238,7 @@ The visualized data is stored in `company-prefix', `company-candidates',
                          (const :tag "pseudo tooltip, multiple only"
                                 company-pseudo-tooltip-unless-just-one-frontend)
                          (const :tag "pseudo tooltip, multiple only, delayed"
-                                company-pseudo-tooltip-frontend-with-delay)
+                                company-pseudo-tooltip-unless-just-one-frontend-with-delay)
                          (const :tag "preview" company-preview-frontend)
                          (const :tag "preview, unique only"
                                 company-preview-if-just-one-frontend)
@@ -567,7 +567,7 @@ happens.  The value of nil means no idle completion."
 
 (defcustom company-tooltip-idle-delay .5
   "The idle delay in seconds until tooltip is shown when using
-`company-pseudo-tooltip-frontend-with-delay'."
+`company-pseudo-tooltip-unless-just-one-frontend-with-delay'."
   :type '(choice (const :tag "never (nil)" nil)
                  (const :tag "immediate (0)" 0)
                  (number :tag "seconds")))
@@ -2076,7 +2076,7 @@ With ARG, move by that many elements."
 
 (defun company-select-next-if-tooltip-visible-or-complete-selection ()
   "Insert selection if only preview is showing or only one candidate, or select the next candidate.
-When used with with `company-pseudo-tooltip-frontend-with-delay',
+When used with with `company-pseudo-tooltip-unless-just-one-frontend-with-delay',
 if tooltip is not visible or only one candidate, complete selection,
 else, select-active-regions the next candidate."
   (interactive)
@@ -2854,7 +2854,7 @@ Returns a negative number if the tooltip should be displayed above point."
                (company--show-inline-p))
     (company-pseudo-tooltip-frontend command)))
 
-(defun company-pseudo-tooltip-frontend-with-delay (command)
+(defun company-pseudo-tooltip-unless-just-one-frontend-with-delay (command)
   "`compandy-pseudo-tooltip-frontend', but shown after a delay.
 Delay is determined by `company-tooltip-idle-delay'."
   (cl-case command
@@ -2869,7 +2869,7 @@ Delay is determined by `company-tooltip-idle-delay'."
          (company-pseudo-tooltip-unless-just-one-frontend command)
        (setq company-tooltip-timer
              (run-with-timer company-tooltip-idle-delay nil
-                             'company-pseudo-tooltip-frontend-with-delay
+                             'company-pseudo-tooltip-unless-just-one-frontend-with-delay
                              'post-command))))
     (t
      (company-pseudo-tooltip-unless-just-one-frontend command))))

--- a/company.el
+++ b/company.el
@@ -773,16 +773,6 @@ means that `company-mode' is always turned on except in `message-mode' buffers."
                    (t (memq major-mode company-global-modes))))
     (company-mode 1)))
 
-(defun company-ac-setup ()
-  "Sets up company to behave similarly to auto-complete mode."
-  (setq company-require-match nil)
-  (setq company-auto-complete #'company-tooltip-visible)
-  (setq company-frontends '(company-echo-metadata-frontend
-                            company-ac-frontend
-                            company-preview-frontend))
-  (define-key company-active-map [tab] 'company-ac-complete)
-  (define-key company-active-map (kbd "TAB") 'company-ac-complete))
-
 (defsubst company-assert-enabled ()
   (unless company-mode
     (company-uninstall-map)

--- a/company.el
+++ b/company.el
@@ -188,9 +188,9 @@ buffer-local wherever it is set."
   (let ((value (delete-dups (copy-sequence value))))
     (and (or (and (memq 'company-pseudo-tooltip-unless-just-one-frontend value)
                   (memq 'company-pseudo-tooltip-frontend value))
-             (and (memq 'company-ac-frontend value)
+             (and (memq 'company-pseudo-tooltip-frontend-with-delay value)
                   (memq 'company-pseudo-tooltip-frontend value))
-             (and (memq 'company-ac-frontend value)
+             (and (memq 'company-pseudo-tooltip-frontend-with-delay value)
                   (memq 'company-pseudo-tooltip-unless-just-one-frontend value)))
          (error "Pseudo tooltip frontend cannot be used more than once"))
     (and (memq 'company-preview-if-just-one-frontend value)
@@ -238,7 +238,7 @@ The visualized data is stored in `company-prefix', `company-candidates',
                          (const :tag "pseudo tooltip, multiple only"
                                 company-pseudo-tooltip-unless-just-one-frontend)
                          (const :tag "pseudo tooltip, multiple only, delayed"
-                                company-ac-frontend)
+                                company-pseudo-tooltip-frontend-with-delay)
                          (const :tag "preview" company-preview-frontend)
                          (const :tag "preview, unique only"
                                 company-preview-if-just-one-frontend)
@@ -564,8 +564,8 @@ happens.  The value of nil means no idle completion."
                  (number :tag "seconds")))
 
 (defcustom company-tooltip-idle-delay .5
-  "The idle delay in seconds until tooltip when using
-`company-ac-frontend'."
+  "The idle delay in seconds until tooltip is shown when using
+`company-pseudo-tooltip-frontend-with-delay'."
   :type '(choice (const :tag "never (nil)" nil)
                  (const :tag "immediate (0)" 0)
                  (number :tag "seconds")))
@@ -2062,11 +2062,9 @@ With ARG, move by that many elements."
                  (eq old-tick (buffer-chars-modified-tick)))
         (company-complete-common))))))
 
-(defun company-ac-complete ()
-  "This should be used with `company-ac-frontend'.
-Mimics the way auto-complete does its completion.
-If tooltip is showing, select the next candidate.
-If only preview is showing or only one candidate, complete the selection."
+(defun company-complete-selection-or-select-next-if-tooltip-visible ()
+  "This should be used with `company-pseudo-tooltip-frontend-with-delay'.
+Insert selection if only preview is showing or only one candidate, or select the next candidate."
   (interactive)
   (if (and (company-tooltip-visible) (> company-candidates-length 1))
       (call-interactively 'company-select-next)
@@ -2842,9 +2840,9 @@ Returns a negative number if the tooltip should be displayed above point."
                (company--show-inline-p))
     (company-pseudo-tooltip-frontend command)))
 
-(defun company-ac-frontend (command)
+(defun company-pseudo-tooltip-frontend-with-delay (command)
   "`compandy-pseudo-tooltip-frontend', but shown after a delay.
-Similar to auto-complete mode."
+Delay is determined by `company-tooltip-idle-delay'."
   (when (and (eq command 'pre-command) company-tooltip-timer)
     (cancel-timer company-tooltip-timer)
     (setq company-tooltip-timer nil))


### PR DESCRIPTION
Added company-ac-frontend to mimic auto-complete's delayed popup.

Added company-ac-complete to mimic (approximation) auto-complete's tab behavior.

Added convenience method company-ac-setup to approximate similar
auto-complete behavior without user intervention.

Notes: (Mostly referencing below issue 123)
- Seemed like the feature was never merged in, I pulled in @kencoken's changes and added some more changes (approximating auto-complete's behavior) to bring it to a finish. The naming change recommendations were done as well as pushing the timer cancellation to the precommand.

- From the issue thread, looks like it was might be better to add the additional functionality to the preexisting frontend. I think splitting the frontend out is cleaner and easier to implement (for me anyways).

- Tried my best to put code where it should be but it could possibly use some improvements.

- Not sure if company-tooltip-visible is needed but I wasn't able to find an easy way to check if the tooltip was currently visible.

- I think the auto-complete behavior might still defer slightly from this but it's a very close approximation and in some ways better (in my opinion).

- I can sign any licensing forms.

In reference to: 
https://github.com/company-mode/company-mode/issues/123

Other similar topics:
https://github.com/company-mode/company-mode/issues/216
https://github.com/company-mode/company-mode/issues/246#issuecomment-68538735

Lots of credit to: 
https://github.com/kencoken/company-mode/commit/bbbf217643b84471125ddfa7bdc98632656daa4f
