### PR TITLE
Ignore eclim when an eclipse proj does not exist.

### DIFF
--- a/company-eclim.el
+++ b/company-eclim.el
@@ -88,7 +88,8 @@ eclim can only complete correctly when the buffer has been saved."
   (company-eclim--call-process "project_list"))
 
 (defun company-eclim--project-dir ()
-  (if (eq company-eclim--project-dir 'unknown)
+  (if (and (eq company-eclim--project-dir 'unknown)
+           (locate-dominating-file buffer-file-name ".project"))
       (setq company-eclim--project-dir
             (directory-file-name
              (expand-file-name
@@ -98,7 +99,8 @@ eclim can only complete correctly when the buffer has been saved."
 (defun company-eclim--project-name ()
   (or company-eclim--project-name
       (let ((dir (company-eclim--project-dir)))
-        (when dir
+        (when (and dir
+                   (not (eq company-eclim--project-dir 'unknown)))
           (setq company-eclim--project-name
                 (cl-loop for project in (company-eclim--project-list)
                          when (equal (cdr (assoc 'path project)) dir)


### PR DESCRIPTION
The `company-eclim` completion backend is triggered inside Java files,
but the function `company-eclim--project-dir` fails and throws a
backtrace if the Java file is not part of an Eclipse project.

This happens because the call to `locate-dominating-file` returns nil
when such a file does not exist, and `expand-file-name` expects a string
input.

This commit fixes the error path by explicitly checking that
`locate-dominating-file` returns a non-nil value.