### PR TITLE
Make company-nxml backend more schema aware

### DIFF
--- a/company-nxml.el
+++ b/company-nxml.el
@@ -139,9 +139,11 @@ This is based on the premise that a short name indicates significance.")
                                          (company-nxml-attribute-completions
                                           name (rng-match-possible-attribute-names))))))
                   (when candidates
-                    (setq company-nxml-last-command (if arg
-                                                        'company-nxml-attribute
-                                                        'company-nxml-attribute-from-tag))
+                    (if arg
+                        (setq company-nxml-last-command 'company-nxml-attribute)
+                      (setq company-nxml-last-command 'company-nxml-attribute-from-tag
+                            company-prefix "")) ; prevent tag name from acting as a prefix
+
                     candidates)))
     (sorted t)))
 
@@ -221,8 +223,8 @@ Called post completion when inserting a tag name."
     (candidates (cond
                  ((and (eq company-nxml-last-command 'company-nxml-tag)
                        (company-grab company-nxml-in-starttag-name-regexp 1 1))
-                  (setq company-prefix "") ; don't zap the just inserted tag name!
-                  (company-nxml-attribute 'candidates))
+                  (or (company-nxml-attribute 'candidates)
+                      (company-nxml-tag 'candidates arg)))
                  ((company-nxml-tag 'prefix)
                   (company-nxml-tag 'candidates arg))
                  ((company-nxml-attribute 'prefix)

--- a/company-nxml.el
+++ b/company-nxml.el
@@ -143,7 +143,6 @@ This is based on the premise that a short name indicates significance.")
                         (setq company-nxml-last-command 'company-nxml-attribute)
                       (setq company-nxml-last-command 'company-nxml-attribute-from-tag
                             company-prefix "")) ; prevent tag name from acting as a prefix
-
                     candidates)))
     (sorted t)))
 
@@ -169,7 +168,8 @@ Called post completion when inserting a tag name."
         (message "Auto-inserted %srequired attribute%s for element %s"
                  (or (and (cdr atts) (format "%d " (length atts))) "")
                  (or (and (cdr atts) "s") (concat " " (cdr (car atts))))
-                 tagname)))))
+                 tagname)))
+    atts))
 
 
 (defun company-nxml-attribute-completions (prefix alist)
@@ -217,8 +217,8 @@ Called post completion when inserting a tag name."
   (interactive (list 'interactive))
   (cl-case command
     (interactive (company-begin-backend 'company-nxml))
-    (prefix (or (company-nxml-tag 'prefix)
-                (company-nxml-attribute 'prefix)
+    (prefix (or (company-nxml-attribute 'prefix)
+                (company-nxml-tag 'prefix)
                 (company-nxml-attribute-value 'prefix)))
     (candidates (cond
                  ((and (eq company-nxml-last-command 'company-nxml-tag)
@@ -234,7 +234,10 @@ Called post completion when inserting a tag name."
                         'string<))))
     (post-completion (cond
                       ((eq company-nxml-last-command 'company-nxml-tag)
-                       (company-nxml-add-required-attributes arg (point)))
+                       (if (eq (aref arg 0) ?/)
+                           (insert ">")
+                         (or (company-nxml-add-required-attributes arg (point))
+                             (signal 'quit nil)))) ; this makes multiple attribute candidates work
                       ((eq company-nxml-last-command 'company-nxml-attribute-from-tag)
                        (backward-char (length arg))
                        (insert " ")


### PR DESCRIPTION
With a RELAX NG schema loaded for the current buffer completion is more 
context sensitive and schema aware.

When in tag name context (after a '<'), requesting completion will
- auto-insert the next required element or default to presenting the candidate 
  list of optional elements along with the end tag for the current element
- auto-insert all required attributes
- prepare the next completion request to either
  - auto-insert the sole optional attribute or 
  - present the candidate list of optional attribute names. 
  
  This requires that the last completion action inserted a tag name but does
  not require a space to be manually inserted after the tag name.

Attributes are always inserted as attname="" with point positioned after the first quote.

Attribute completion is available at all legal positions in open as well as already
closed tags.
