### PR TITLE
Fixed company-semantic-annotation, so that it ..

### DIFF
--- a/company-semantic.el
+++ b/company-semantic.el
@@ -40,6 +40,7 @@
 (declare-function semantic-tag-buffer "semantic/tag")
 (declare-function semantic-active-p "semantic")
 (declare-function semantic-format-tag-prototype "semantic/format")
+(declare-function semantic-format-tag-canonical-name "semantic/format")
 
 (defgroup company-semantic nil
   "Completion backend using Semantic."
@@ -119,9 +120,15 @@ and `c-electric-colon', for automatic completion right after \">\" and
   (let* ((tag (assq argument tags))
          (kind (when tag (elt tag 1))))
     (cl-case kind
-      (function (let* ((prototype (semantic-format-tag-prototype tag nil nil))
-                       (par-pos (string-match "(" prototype)))
-                  (when par-pos (substring prototype par-pos)))))))
+             (function (let* ((prototype
+                               (semantic-format-tag-prototype tag nil nil))
+                              (cname ; semantics' idea of a 'canonical' name for tag          
+                               (semantic-format-tag-canonical-name tag nil nil))
+                              (coff  ; offset to end of 'canonical' name (i.e. it's len)      
+                               (string-bytes cname))
+                              (cpos  ; start pos of 'canonical' name in prototype             
+                               (string-match cname prototype)))
+                         (when cpos (substring prototype (- (+ cpos coff) 1))))))))
 
 (defun company-semantic--prefix ()
   (if company-semantic-begin-after-member-access


### PR DESCRIPTION
.. can appropriately deal with function pointers in C.

As an example of the original problem, consider the struct

`struct blah { int (*hates)(uint8_t, uint32_t);  void *blank; }`

   
the annotation returned by company-semantic-annotation for 'hates' would be
         `(*hates)(uint8_t, uint32_t)`
which when coupled with the default value of 'company-semantic-insert-arguments'
yields decidedly annoying results. 

This patch fixes the problem. Additionally. I've attached a sequence of screenshots
illustrating the problem.

![prepatch](https://cloud.githubusercontent.com/assets/1260730/16439615/4633effc-3d88-11e6-9129-aad437fdf90a.png)
![prepatch2](https://cloud.githubusercontent.com/assets/1260730/16439612/462f8912-3d88-11e6-88f1-70b642fc6364.png)
![prepatch3](https://cloud.githubusercontent.com/assets/1260730/16439613/46308d30-3d88-11e6-820d-cbc2d5e358bf.png)
![postpatch](https://cloud.githubusercontent.com/assets/1260730/16439614/4631303c-3d88-11e6-8b14-8eaf8f2f4955.png)
![postpatch2](https://cloud.githubusercontent.com/assets/1260730/16439611/462dd8c4-3d88-11e6-8927-4a9dd44abc75.png)
![postpatch3](https://cloud.githubusercontent.com/assets/1260730/16439616/4638d076-3d88-11e6-8e1b-004d3bd23342.png)

The issue with the original code seems to be the implicit assumption that the 
type of blah::hates is not seen as a function by semantic. This is incorrect, as 
semantic properly designates it a function-pointer which being callable, makes it 
a function.