### PR TITLE
Don't convert user-error signals to error

### DIFF
--- a/company.el
+++ b/company.el
@@ -898,6 +898,9 @@ matches IDLE-BEGIN-AFTER-RE, return it wrapped in a cons."
       (if (functionp company-backend)
           (apply company-backend args)
         (apply #'company--multi-backend-adapter company-backend args))
+    (user-error (user-error
+                 "Company: backend %s user-error: %s"
+                 company-backend (error-message-string err)))
     (error (error "Company: backend %s error \"%s\" with args %s"
                   company-backend (error-message-string err) args))))
 


### PR DESCRIPTION
If a backend calls (user-error ...), we want to preserve Emacs' behavior
of not opening a debugger, even when debug-on-error is enabled.