### PR TITLE
Better search visualization. Added company-tooltip-search-selection.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * `company-pseudo-tooltip-unless-just-one-frontend-with-delay` handles custom
   frontends derived from `company-preview-frontend` better.
 * `company-idle-delay` is automatically adjusted to a non-zero value.
+* New face `company-tooltip-search-selection` and better visualization of search matches.
 
 ## 2016-06-23 (0.9.0)
 

--- a/company.el
+++ b/company.el
@@ -123,7 +123,7 @@ attention to case differences."
 
 (defface company-tooltip-search-selection
   '((default :inherit highlight))
-  "Face used for the selected search string in the tooltip.")
+  "Face used for the search string inside the selection in the tooltip.")
 
 (defface company-tooltip-mouse
   '((default :inherit highlight))

--- a/company.el
+++ b/company.el
@@ -118,14 +118,11 @@ attention to case differences."
   "Face used for the selection in the tooltip.")
 
 (defface company-tooltip-search
-  '((t (:foreground "orange")))
+  '((default :inherit highlight))
   "Face used for the search string in the tooltip.")
 
 (defface company-tooltip-search-selection
-  '((((background light))
-     :foreground "orange")
-    (((background dark))
-     :foreground "yellow"))
+  '((default :inherit highlight))
   "Face used for the selected search string in the tooltip.")
 
 (defface company-tooltip-mouse

--- a/company.el
+++ b/company.el
@@ -118,8 +118,15 @@ attention to case differences."
   "Face used for the selection in the tooltip.")
 
 (defface company-tooltip-search
-  '((default :inherit company-tooltip-selection))
+  '((t (:foreground "orange")))
   "Face used for the search string in the tooltip.")
+
+(defface company-tooltip-search-selection
+  '((((background light))
+     :foreground "orange")
+    (((background dark))
+     :foreground "yellow"))
+  "Face used for the selected search string in the tooltip.")
 
 (defface company-tooltip-mouse
   '((default :inherit highlight))
@@ -2475,22 +2482,24 @@ If SHOW-VERSION is non-nil, show the version in the echo area."
                                          'company-tooltip-common-selection
                                        'company-tooltip-common)
                                      line)
-    (when selected
-      (if (let ((re (funcall company-search-regexp-function
+    (when (let ((re (funcall company-search-regexp-function
                              company-search-string)))
             (and (not (string= re ""))
                  (string-match re value (length company-prefix))))
-          (pcase-dolist (`(,mbeg . ,mend) (company--search-chunks))
-            (let ((beg (+ margin mbeg))
-                  (end (+ margin mend))
-                  (width (- width (length right))))
-              (when (< beg width)
-                (font-lock-prepend-text-property beg (min end width)
-                                                 'face 'company-tooltip-search
-                                                 line))))
-        (font-lock-append-text-property 0 width 'face
-                                        'company-tooltip-selection
-                                        line)))
+      (pcase-dolist (`(,mbeg . ,mend) (company--search-chunks))
+        (let ((beg (+ margin mbeg))
+              (end (+ margin mend))
+              (width (- width (length right))))
+          (when (< beg width)
+            (font-lock-prepend-text-property beg (min end width) 'face
+                                             (if selected
+                                                 'company-tooltip-search-selection
+                                               'company-tooltip-search)
+                                             line)))))
+    (when selected
+      (font-lock-append-text-property 0 width 'face
+                                      'company-tooltip-selection
+                                      line))
     (font-lock-append-text-property 0 width 'face
                                     'company-tooltip
                                     line)

--- a/test/frontends-tests.el
+++ b/test/frontends-tests.el
@@ -256,18 +256,18 @@
     (should (ert-equal-including-properties
              (company-fill-propertize "barfoo" nil 6 t nil nil)
              #("barfoo"
-               0 3 (face (company-tooltip) mouse-face (company-tooltip-mouse))
-               3 6 (face (company-tooltip-search company-tooltip) mouse-face (company-tooltip-mouse)))))
+               0 3 (face (company-tooltip-selection company-tooltip) mouse-face (company-tooltip-mouse))
+               3 6 (face (company-tooltip-search-selection company-tooltip-selection company-tooltip) mouse-face (company-tooltip-mouse)))))
     (should (ert-equal-including-properties
              (company-fill-propertize "barfoo" nil 5 t "" " ")
              #("barfo "
-               0 3 (face (company-tooltip) mouse-face (company-tooltip-mouse))
-               3 5 (face (company-tooltip-search company-tooltip) mouse-face (company-tooltip-mouse))
-               5 6 (face (company-tooltip) mouse-face (company-tooltip-mouse)))))
+               0 3 (face (company-tooltip-selection company-tooltip) mouse-face (company-tooltip-mouse))
+               3 5 (face (company-tooltip-search-selection company-tooltip-selection company-tooltip) mouse-face (company-tooltip-mouse))
+               5 6 (face (company-tooltip-selection company-tooltip) mouse-face (company-tooltip-mouse)))))
     (should (ert-equal-including-properties
              (company-fill-propertize "barfoo" nil 3 t " " " ")
              #(" bar "
-               0 5 (face (company-tooltip) mouse-face (company-tooltip-mouse)))))))
+               0 5 (face (company-tooltip-selection company-tooltip) mouse-face (company-tooltip-mouse)))))))
 
 (ert-deftest company-fill-propertize-overrides-face-property ()
   (let ((company-backend #'ignore)


### PR DESCRIPTION
This addresses #567.
Added a customizable company-tooltip-search-selection face and changed the default visualization of search matches.

Bright:
<img width="249" alt="bright" src="https://cloud.githubusercontent.com/assets/3673952/17832005/c12a4f8a-66f0-11e6-8b8e-86e245e0342f.png">
Dark:
<img width="285" alt="dark" src="https://cloud.githubusercontent.com/assets/3673952/17832006/c2e00f2c-66f0-11e6-9b60-bddafb4d9a98.png">

Suggestions welcome!