### PR TITLE
tests: use /bin instead of /lost+found

### DIFF
--- a/test/files-tests.el
+++ b/test/files-tests.el
@@ -30,7 +30,7 @@
 
 (ert-deftest company-files-candidates-normal-root ()
   (let (company-files--completion-cache)
-    (should (member "/lost+found/"
+    (should (member "/bin/"
                     (company-files 'candidates "/")))))
 
 (ert-deftest company-files-candidates-excluding-dir ()


### PR DESCRIPTION
`/lost+found` isn't guaranteed to exist on a filesystem, so this
switches to something that is.