### PR TITLE
Add alias for enh-ruby-mode for company-keywords

### DIFF
--- a/company-keywords.el
+++ b/company-keywords.el
@@ -239,7 +239,8 @@
     (js-jsx-mode . javascript-mode)
     (cperl-mode . perl-mode)
     (jde-mode . java-mode)
-    (ess-julia-mode . julia-mode))
+    (ess-julia-mode . julia-mode)
+    (enh-ruby-mode . ruby-mode))
   "Alist mapping major-modes to sorted keywords for `company-keywords'.")
 
 ;;;###autoload


### PR DESCRIPTION
This adds an alias for enh-ruby-mode to ruby-mode for those who use
`enh-ruby-mode` instead of the `ruby-mode` and wants to use the
`company-keywords` backend.