### PR TITLE
Use pipes instead of PTYs to receive output from Clang

### DIFF
--- a/company-clang.el
+++ b/company-clang.el
@@ -208,8 +208,9 @@ or automatically through a custom `company-clang-prefix-guesser'."
       (with-current-buffer buf
         (erase-buffer)
         (setq buffer-undo-list t))
-      (let ((process (apply #'start-process "company-clang" buf
-                            company-clang-executable args)))
+      (let* ((process-connection-type nil)
+             (process (apply #'start-process "company-clang" buf
+                             company-clang-executable args)))
         (set-process-sentinel
          process
          (lambda (proc status)


### PR DESCRIPTION
We don't need any job control features. Also Pipes are more efficient and more
robust than PTYs, which Emacs uses by default.

Fixes #620.