### PR TITLE
company-diag: Also show completions if prefix is a cons

### DIFF
--- a/company.el
+++ b/company.el
@@ -2345,7 +2345,7 @@ If SHOW-VERSION is non-nil, show the version in the echo area."
                                     (setq backend b)
                                     (company-call-backend 'prefix))))
          cc annotations)
-    (when (stringp prefix)
+    (when (or (stringp prefix) (consp prefix))
       (let ((company-backend backend))
         (setq cc (company-call-backend 'candidates prefix)
               annotations


### PR DESCRIPTION
Fixes this issue:
```

Emacs 25.1.1 (x86_64-unknown-linux-gnu) of 2016-12-23 on juergen
Company 0.9.2

company-backends: (fsharp-ac/company-backend company-rtags company-omnisharp merlin-company-backend company-bbdb company-nxml company-css company-eclim company-semantic company-clang company-xcode company-cmake company-capf company-files
			   (company-dabbrev-code company-gtags company-etags company-keywords)
			   company-oddmuse company-dabbrev)

Used backend: fsharp-ac/company-backend
Prefix: ("Sys" . t)

Completions: none
```

With commit:

```
Emacs 25.1.1 (x86_64-unknown-linux-gnu) of 2016-12-23 on juergen
Company 0.9.2

company-backends: (fsharp-ac/company-backend company-rtags company-omnisharp merlin-company-backend company-bbdb company-nxml company-css company-eclim company-semantic company-clang company-xcode company-cmake company-capf company-files
			   (company-dabbrev-code company-gtags company-etags company-keywords)
			   company-oddmuse company-dabbrev)

Used backend: fsharp-ac/company-backend
Prefix: ("Sys" . t)

Completions:
  #("System" 0 6 (annotation "N")) "N"
```

:fireworks: 