### PR TITLE
Disable idle completion on remote buffers

### DIFF
--- a/company-clang.el
+++ b/company-clang.el
@@ -209,7 +209,7 @@ or automatically through a custom `company-clang-prefix-guesser'."
         (erase-buffer)
         (setq buffer-undo-list t))
       (let* ((process-connection-type nil)
-             (process (apply #'start-process "company-clang" buf
+             (process (apply #'start-file-process "company-clang" buf
                              company-clang-executable args)))
         (set-process-sentinel
          process

--- a/company.el
+++ b/company.el
@@ -1379,6 +1379,7 @@ prefix match (same case) will be prioritized."
        (eq win (selected-window))
        (eq tick (buffer-chars-modified-tick))
        (eq pos (point))
+       (or (company-explicit-action-p) (not (file-remote-p default-directory)))
        (when (company-auto-begin)
          (company-input-noop)
          (let ((this-command 'company-idle-begin))


### PR DESCRIPTION
This disables idle-completion in TRAMP buffers (due to ```(eq non-essential t)```. and fixes [Support for remote files via TRAMP](https://github.com/company-mode/company-mode/issues/462)

Also see related: [Bind non-essential to prevent tramp error ](https://github.com/company-mode/company-mode/pull/487)