### PR TITLE
Set company-template-nav-map as parent of company-template-field-map

### DIFF
--- a/company-template.el
+++ b/company-template.el
@@ -37,6 +37,7 @@
 
 (defvar company-template-field-map
   (let ((keymap (make-sparse-keymap)))
+    (set-keymap-parent keymap company-template-nav-map)
     (define-key keymap (kbd "C-d") 'company-template-clear-field)
     keymap))
 


### PR DESCRIPTION
In order to be able to forward a field while company-template-field-map is
active, we need to set company-template-nav-map as parent.

This is a regression introduced in #660 
I thought I tested this, but it slipped through.