### PR TITLE
Fix default company-tng configuration

### DIFF
--- a/company-tng.el
+++ b/company-tng.el
@@ -88,8 +88,7 @@ confirm the selection and finish the completion."
        (move-overlay ov (- (point) prefix) (point))
        (overlay-put ov
                     (if (= prefix 0) 'after-string 'display)
-                    (and company-selection-changed selected))
-       (overlay-put ov 'display (and company-selection-changed selected))))
+                    (and company-selection-changed selected))))
     (hide
      (when company-tng--overlay
        (delete-overlay company-tng--overlay)

--- a/company-tng.el
+++ b/company-tng.el
@@ -104,7 +104,9 @@ confirm the selection and finish the completion."
 ;;;###autoload
 (defun company-tng-configure-default ()
   "Applies the default configuration to enable company-tng."
-  (add-to-list 'company-frontends 'company-tng-frontend)
+  (setq company-frontends '(company-tng-frontend
+                            company-pseudo-tooltip-frontend
+                            company-echo-metadata-frontend))
   (let ((keymap company-active-map))
     (define-key keymap [return] nil)
     (define-key keymap (kbd "RET") nil)


### PR DESCRIPTION
Following #706, we discovered that the default configuration for `company-tng` behaves funny when there is only one candidate. This PR fixes it by changing the default frontends. More information about the changes is available in the commit messages.

Whether this is the best default configuration is open to discussion, but this PR should be merged anyway to unbreak master.