### PR TITLE
allow company-cmake to complete in strings if prefixed with "${"

### DIFF
--- a/company-cmake.el
+++ b/company-cmake.el
@@ -179,26 +179,24 @@ They affect which types of symbols we get completion candidates for.")
 
 (defun company-cmake-prefix-dollar-brace-p ()
   "Test if the current char is prefix with ${ in the current line."
-  (setq-local position-current (point))
-  (setq-local position-beg-of-line (line-beginning-position))
-  (setq-local position-end-of-line (line-end-position))
+  (let ((position-current (point))
+        (position-beg-of-line (line-beginning-position))
+        (position-end-of-line (line-end-position)))
 
-  (if (re-search-backward "\$\{" position-beg-of-line t)
-      (setq-local position-matched (point))
-    (setq-local position-matched nil))
-  (goto-char position-current)
-  (if (re-search-backward "\}" position-beg-of-line t)
-      (setq-local position-matched-right-brace (point))
-    (setq-local position-matched-right-brace nil))
-  (goto-char position-current)
+    (setq-local position-matched
+                (re-search-backward "\$\{" position-beg-of-line t))
+    (goto-char position-current)
+    (setq-local position-matched-right-brace
+                (re-search-backward "\}" position-beg-of-line t))
+    (goto-char position-current)
 
-  (if (or (and position-matched
-               position-matched-right-brace
-               (> position-matched position-matched-right-brace))
-          (and position-matched
-               (not position-matched-right-brace)))
-      t
-    nil))
+    (if (or (and position-matched
+                 position-matched-right-brace
+                 (> position-matched position-matched-right-brace))
+            (and position-matched
+                 (not position-matched-right-brace)))
+        t
+      nil)))
 
 (defun company-cmake (command &optional arg &rest ignored)
   "`company-mode' completion backend for CMake.

--- a/company-cmake.el
+++ b/company-cmake.el
@@ -177,7 +177,7 @@ They affect which types of symbols we get completion candidates for.")
        (buffer-substring-no-properties (line-beginning-position)
                                        (point-max))))))
 
-(defun company-cmake-prefox-dollar-brace-p ()
+(defun company-cmake-prefix-dollar-brace-p ()
   "Test if the current char is prefix with ${ in the current line."
   (setq-local position-current (point))
   (setq-local position-beg-of-line (line-beginning-position))

--- a/company-cmake.el
+++ b/company-cmake.el
@@ -181,12 +181,14 @@ They affect which types of symbols we get completion candidates for.")
   "Test if the current char is prefix with ${ in the current line."
   (let ((position-current (point))
         (position-beg-of-line (line-beginning-position))
-        (position-end-of-line (line-end-position)))
+        (position-end-of-line (line-end-position))
+        (position-matched nil)
+        (position-matched-right-brace nil))
 
-    (setq-local position-matched
+    (setq position-matched
                 (re-search-backward "\$\{" position-beg-of-line t))
     (goto-char position-current)
-    (setq-local position-matched-right-brace
+    (setq position-matched-right-brace
                 (re-search-backward "\}" position-beg-of-line t))
     (goto-char position-current)
 

--- a/test/cmake-test.el
+++ b/test/cmake-test.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2016  Free Software Foundation, Inc.
 
-;; Author: oracleyue
+;; Author: Zuogong Yue
 
 ;; This file is part of GNU Emacs.
 
@@ -21,9 +21,6 @@
 
 (require 'company-tests)
 (require 'company-cmake)
-
-;; (load-file "./company-cmake.el")
-;; (load-file "./company-cmake-fix.el")
 
 (require 'cmake-mode)
 

--- a/test/cmake-test.el
+++ b/test/cmake-test.el
@@ -1,0 +1,68 @@
+;;; cmake-tests.el --- company-mode tests  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2016  Free Software Foundation, Inc.
+
+;; Author: oracleyue
+
+;; This file is part of GNU Emacs.
+
+;; GNU Emacs is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+
+(require 'company-tests)
+(require 'company-cmake)
+
+;; (load-file "./company-cmake.el")
+;; (load-file "./company-cmake-fix.el")
+
+(require 'cmake-mode)
+
+
+(ert-deftest company-cmake-complete-in-string-prefix-quotes ()
+  (with-temp-buffer
+    (insert "set(MyFlags \"${CMAKE_CXX_FLAGS_R")
+    (setq-local major-mode 'cmake-mode)
+    (should (equal (company-cmake 'prefix)
+                   "CMAKE_CXX_FLAGS_R"))
+    (should (equal (company-cmake 'candidates "CMAKE_CXX_FLAGS_R")
+                   '("CMAKE_CXX_FLAGS_RELWITHDEBINFO" "CMAKE_CXX_FLAGS_RELEASE")))))
+
+
+(ert-deftest company-cmake-complete-in-string-between-quotes ()
+  (with-temp-buffer
+    (insert "set(MyFlags \"${CMAKE_CXX_FLAGS_R}\"")
+    (backward-char 2)
+    (setq-local major-mode 'cmake-mode)
+    (should (equal (company-cmake 'prefix)
+                   "CMAKE_CXX_FLAGS_R"))
+    (should (equal (company-cmake 'candidates "CMAKE_CXX_FLAGS_R")
+                   '("CMAKE_CXX_FLAGS_RELWITHDEBINFO" "CMAKE_CXX_FLAGS_RELEASE")))))
+
+
+(ert-deftest company-cmake-complete-in-string-more-prefix ()
+  (with-temp-buffer
+    (insert "set(MyFlags \"${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_R")
+    (setq-local major-mode 'cmake-mode)
+    (should (equal (company-cmake 'prefix)
+                   "CMAKE_CXX_FLAGS_R"))
+    (should (equal (company-cmake 'candidates "CMAKE_CXX_FLAGS_R")
+                   '("CMAKE_CXX_FLAGS_RELWITHDEBINFO" "CMAKE_CXX_FLAGS_RELEASE")))))
+
+(ert-deftest company-cmake-complete-in-string-more-prefix-2 ()
+  (with-temp-buffer
+    (insert "set(MyFlags \"${CMAKE_CXX_FLAGS} CMAKE_CXX_FLAGS_R")
+    (setq-local major-mode 'cmake-mode)
+    (should (equal (company-cmake 'prefix)
+                   nil))))
+
+;; (ert t)

--- a/test/cmake-tests.el
+++ b/test/cmake-tests.el
@@ -1,6 +1,6 @@
 ;;; cmake-tests.el --- company-mode tests  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2016  Free Software Foundation, Inc.
+;; Copyright (C) 2017  Free Software Foundation, Inc.
 
 ;; Author: Zuogong Yue
 
@@ -22,18 +22,12 @@
 (require 'company-tests)
 (require 'company-cmake)
 
-(require 'cmake-mode)
-
-
 (ert-deftest company-cmake-complete-in-string-prefix-quotes ()
   (with-temp-buffer
     (insert "set(MyFlags \"${CMAKE_CXX_FLAGS_R")
     (setq-local major-mode 'cmake-mode)
     (should (equal (company-cmake 'prefix)
-                   "CMAKE_CXX_FLAGS_R"))
-    (should (equal (company-cmake 'candidates "CMAKE_CXX_FLAGS_R")
-                   '("CMAKE_CXX_FLAGS_RELWITHDEBINFO" "CMAKE_CXX_FLAGS_RELEASE")))))
-
+                   "CMAKE_CXX_FLAGS_R"))))
 
 (ert-deftest company-cmake-complete-in-string-between-quotes ()
   (with-temp-buffer
@@ -41,19 +35,14 @@
     (backward-char 2)
     (setq-local major-mode 'cmake-mode)
     (should (equal (company-cmake 'prefix)
-                   "CMAKE_CXX_FLAGS_R"))
-    (should (equal (company-cmake 'candidates "CMAKE_CXX_FLAGS_R")
-                   '("CMAKE_CXX_FLAGS_RELWITHDEBINFO" "CMAKE_CXX_FLAGS_RELEASE")))))
-
+                   "CMAKE_CXX_FLAGS_R"))))
 
 (ert-deftest company-cmake-complete-in-string-more-prefix ()
   (with-temp-buffer
     (insert "set(MyFlags \"${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_R")
     (setq-local major-mode 'cmake-mode)
     (should (equal (company-cmake 'prefix)
-                   "CMAKE_CXX_FLAGS_R"))
-    (should (equal (company-cmake 'candidates "CMAKE_CXX_FLAGS_R")
-                   '("CMAKE_CXX_FLAGS_RELWITHDEBINFO" "CMAKE_CXX_FLAGS_RELEASE")))))
+                   "CMAKE_CXX_FLAGS_R"))))
 
 (ert-deftest company-cmake-complete-in-string-more-prefix-2 ()
   (with-temp-buffer
@@ -61,5 +50,3 @@
     (setq-local major-mode 'cmake-mode)
     (should (equal (company-cmake 'prefix)
                    nil))))
-
-;; (ert t)


### PR DESCRIPTION
#### Description
For example, in the following case as illustrated, we definitely want the company to complete it. Most functions in cmake could be memorized, while these variables are really nasty. We will expect company to help us.

<img width="470" alt="screen shot 2017-09-27 at 15 35 38" src="https://user-images.githubusercontent.com/5046605/30916436-b6b1913a-a399-11e7-9edf-565095f1b0a7.png">

#### Method

Search `${` backwards from the current point, raise completion if `${` is found and there is no `}` after the matched position.

In the testing conditions, it is used with combination of `company-in-string-or-comment`.