### PR TITLE
Place cursor at correct location for completions

### DIFF
--- a/company-clang.el
+++ b/company-clang.el
@@ -263,7 +263,7 @@ or automatically through a custom `company-clang-prefix-guesser'."
   (apply 'company-clang--start-process
          prefix
          callback
-         (company-clang--build-complete-args (- (point) (length prefix)))))
+         (company-clang--build-complete-args (point))))
 
 (defun company-clang--prefix ()
   (if company-clang-begin-after-member-access


### PR DESCRIPTION
This patch makes the company-clang backend work much better for me.  I don't know if it will ruin any expected behavior or break anything else.  Please look it over and let me know what you think.

What I can say is that in my limited testing it makes company-clang perform much, much better.  Here is a very small example:

```
struct Foo {};
int main () {
    Fo(point)
}
```

In this code file, point is located at position `3:6`.  Using the old code, clang is asked for the code completion at location `3:5`, one character past the beginning of the prefix.  On my machine this results in a [large list of completions](https://pastebin.com/QsvfTNw0) (using clang 5.0.0).  Despite the number of completions, statement is completed to `Foo` anyway.

After the changes in this patch, clang is asked for code completion at location `3:6`, clang only produces one possible completion: `COMPLETION: Foo : Foo` and again, the statement is completed to `Foo`.

In small files there's not much of a difference, but in large files and after multiple includes it makes a huge difference.  In a project I'm working on (1000-line file), before the change, company-clang times out when I ask it for completions mid-file even when I give it thousands of seconds, whereas after the change it finds the right completion in seconds.