### PR TITLE
company-tng: default config: Disable company-require-match

### DIFF
--- a/company-tng.el
+++ b/company-tng.el
@@ -60,6 +60,9 @@
 ;; candidates. You also need to decide which keys to unbind, depending
 ;; on whether you want them to do the Company action or the default
 ;; Emacs action (for example C-s or C-w).
+;;
+;; We recommend to disable `company-require-match' to allow free typing at any
+;; point.
 
 ;;; Code:
 
@@ -104,6 +107,7 @@ confirm the selection and finish the completion."
 ;;;###autoload
 (defun company-tng-configure-default ()
   "Applies the default configuration to enable company-tng."
+  (setq company-require-match nil)
   (setq company-frontends '(company-tng-frontend
                             company-pseudo-tooltip-frontend
                             company-echo-metadata-frontend))


### PR DESCRIPTION
This issue was reported by @rswgnu as part of a discussion at #743.

Requiring a match doesn't work with company-tng because the expected behavior is to be able to type any key during completion and it will be inserted into the buffer.

The default value for company-require-match is to require match on explicit action, so we can reproduce as following:

1. Open \*scratch\*
2. Type "(de"
3. M-x company-complete
4. RET RET RET...

The RET won't register because it's not part of the completion but this is not how company-tng should work. The RETs should be inserted into the buffer.