### PR TITLE
Fix defcustom

### DIFF
--- a/company-dabbrev.el
+++ b/company-dabbrev.el
@@ -59,7 +59,11 @@ Or a function that returns non-nil for such buffers."
 (defcustom company-dabbrev-ignore-case 'keep-prefix
   "Non-nil to ignore case when collecting completion candidates.
 When it's `keep-prefix', the text before point will remain unchanged after
-candidate is inserted, even some of its characters have different case.")
+candidate is inserted, even some of its characters have different case."
+  :type '(choice
+          (const :tag "Don't ignore case" nil)
+          (const :tag "Ignore case" ignore-case)
+          (const :tag "Keep case before point" keep-prefix)))
 
 (defcustom company-dabbrev-downcase 'case-replace
   "Whether to downcase the returned candidates.
@@ -69,7 +73,11 @@ The value of nil means keep them as-is.
 Any other value means downcase.
 
 If you set this value to nil, you may also want to set
-`company-dabbrev-ignore-case' to any value other than `keep-prefix'.")
+`company-dabbrev-ignore-case' to any value other than `keep-prefix'."
+  :type '(choice
+          (const :tag "Keep as-is" nil)
+          (const :tag "Downcase" downcase)
+          (const :tag "Use case-replace" case-replace)))
 
 (defcustom company-dabbrev-minimum-length 4
   "The minimum length for the completion candidate to be included.

--- a/company-dabbrev.el
+++ b/company-dabbrev.el
@@ -62,7 +62,7 @@ When it's `keep-prefix', the text before point will remain unchanged after
 candidate is inserted, even some of its characters have different case."
   :type '(choice
           (const :tag "Don't ignore case" nil)
-          (const :tag "Ignore case" ignore-case)
+          (const :tag "Ignore case" t)
           (const :tag "Keep case before point" keep-prefix)))
 
 (defcustom company-dabbrev-downcase 'case-replace
@@ -76,7 +76,7 @@ If you set this value to nil, you may also want to set
 `company-dabbrev-ignore-case' to any value other than `keep-prefix'."
   :type '(choice
           (const :tag "Keep as-is" nil)
-          (const :tag "Downcase" downcase)
+          (const :tag "Downcase" t)
           (const :tag "Use case-replace" case-replace)))
 
 (defcustom company-dabbrev-minimum-length 4

--- a/company-semantic.el
+++ b/company-semantic.el
@@ -56,7 +56,8 @@ symbol is preceded by \".\", \"->\" or \"::\", ignoring
 
 If `company-begin-commands' is a list, it should include `c-electric-lt-gt'
 and `c-electric-colon', for automatic completion right after \">\" and
-\":\".")
+\":\"."
+  :type 'boolean)
 
 (defcustom company-semantic-insert-arguments t
   "When non-nil, insert function arguments as a template after completion."


### PR DESCRIPTION
defcustoms that don't specify `:type` result in byte compiler warnings in Emacs 26+