### PR TITLE
company-keywords: Support thrift-mode

### DIFF
--- a/company-keywords.el
+++ b/company-keywords.el
@@ -255,6 +255,12 @@
      "otherwise" "quote" "return" "switch" "throw" "true" "try" "type"
      "typealias" "using" "while"
      )
+    ;; From https://github.com/apache/thrift/blob/master/contrib/thrift.el
+    (thrift-mode
+     "binary" "bool" "byte" "const" "double" "enum" "exception" "extends"
+     "i16" "i32" "i64" "include" "list" "map" "oneway" "optional" "required"
+     "service" "set" "string" "struct" "throws" "typedef" "void"
+     )
     ;; aliases
     (js2-mode . javascript-mode)
     (js2-jsx-mode . javascript-mode)


### PR DESCRIPTION
This changeset enables Thrift IDL support for `company-keywords` backend.

<img width="1280" alt="screenshot 2018-04-24 21 43 32" src="https://user-images.githubusercontent.com/4594897/39213127-9dcccd88-4808-11e8-935f-2654ec3c74f7.png">