### PR TITLE
company-clang: Make message fit in echo area in one line.

### DIFF
--- a/company-clang.el
+++ b/company-clang.el
@@ -187,7 +187,9 @@ or automatically through a custom `company-clang-prefix-guesser'."
                   (buffer-substring-no-properties (point-min)
                                                   (1- (match-beginning 0)))
                 ;; Warn the user more aggressively if no match was found.
-                (message "clang failed with error %d:\n%s" res cmd)
+                (message "clang failed with error %d, see details on %s buffer"
+                         res
+                         company-clang--error-buffer-name)
                 (buffer-string))))
 
     (with-current-buffer buf


### PR DESCRIPTION
With `company-clang-arguments` set to include a bunch of directories, this message will take many "lines" of echo area if clang fails frequently, which is a bit annoying.

So I think it's more appropriate to keep this message short and give a hint to see details.