### PR TITLE
company-yasnippet return nil as prefix when company-grab-symbol returns empty string

### DIFF
--- a/company-yasnippet.el
+++ b/company-yasnippet.el
@@ -62,6 +62,11 @@
             (push prefix prefixes))))
       prefixes)))
 
+(defun company-yasnippet--prefix ()
+  (cl-find (company-grab-symbol)
+           (cl-mapcan 'yas--table-all-keys (yas--get-snippet-tables))
+           :test 'string=))
+
 (defun company-yasnippet--candidates (prefix)
   ;; Process the prefixes in reverse: unlike Yasnippet, we look for prefix
   ;; matches, so the longest prefix with any matches should be the most useful.
@@ -125,10 +130,8 @@ shadow backends that come after it.  Recommended usages:
   (cl-case command
     (interactive (company-begin-backend 'company-yasnippet))
     (prefix
-     ;; Should probably use `yas--current-key', but that's bound to be slower.
-     ;; How many trigger keys start with non-symbol characters anyway?
      (and (bound-and-true-p yas-minor-mode)
-          (company-grab-symbol)))
+          (company-yasnippet--prefix)))
     (annotation
      (concat
       (unless company-tooltip-align-annotations " -> ")


### PR DESCRIPTION
Checks all the trigger keys for all the templates enabled for the current major mode to, if one matches `company-grab-symbol`, return it. This is reasonably fast because the snippet tables are cached, so this is all done in memory.

This implementation returns much more accurate completions and since now prefix may be nil, other backends that come after company-yasnippet will have a chance at completion.