### PR TITLE
Properly fix #809

### DIFF
--- a/company-capf.el
+++ b/company-capf.el
@@ -133,7 +133,7 @@
                    ((and match-start (not has-face-p))
                     (push (cons match-start pos) chunks)
                     (setq match-start nil))))
-           (if chunks (nreverse chunks) (cons 0 (length arg)))))))
+           (nreverse chunks)))))
     (`duplicates t)
     (`no-cache t)   ;Not much can be done here, as long as we handle
                     ;non-prefix matches.

--- a/test/capf-tests.el
+++ b/test/capf-tests.el
@@ -55,6 +55,30 @@
     (should company-candidates)
     (should (member "with-current-buffer" company-candidates))))
 
+(ert-deftest company-basic-capf-highlighting ()
+  "Test basic `company-capf' support, with basic prefix completion."
+  (company-capf-with-buffer
+    "(with|)"
+    (company-mode)
+    (company-complete)
+    (should company-candidates)
+    (let* ((cand (car (member "with-current-buffer" company-candidates)))
+           (render
+            (and cand
+                 (company-fill-propertize cand nil (length cand) nil nil nil))))
+      ;; remove `font-lock-face' and `mouse-face' text properties that aren't
+      ;; relevant to our test
+      (remove-list-of-text-properties
+       0 (length cand) '(font-lock-face mouse-face) render)
+      (should
+       (ert-equal-including-properties
+        render
+        #("with-current-buffer"
+          0 4 (face (company-tooltip-common company-tooltip))   ; "with"
+          4 19 (face (company-tooltip))))))))
+
+
+
 ;; Re. "perfect" highlighting of the non-prefix in company-capf matches, it is
 ;; only working-out-of-the box (i.e. without the `:company-match' meta) in
 ;; recent Emacsen containing the following commit.  The two tests that follow


### PR DESCRIPTION
* company-capf.el (company-capf): Return either a proper list or an
integer.

* test/capf-tests.el (company-basic-capf-highlighting): New test.