### PR TITLE
move golang's keywords to the right place

### DIFF
--- a/company-keywords.el
+++ b/company-keywords.el
@@ -141,6 +141,11 @@
       "sum_suffix" "system_clock" "tan" "tanh" "target" "template" "then"
       "tiny" "transfer" "transpose" "trim" "true" "type" "ubound" "unpack"
       "use" "value" "verify" "volatile" "wait" "where" "while" "with" "write"))
+    (go-mode
+     ;; from https://golang.org/ref/spec#Keywords
+     "break" "case" "chan" "const" "continue" "default" "defer" "else" "fallthrough"
+     "for" "func" "go" "goto" "if" "import" "interface" "map" "package" "range"
+     "return" "select" "struct" "switch" "type" "var")
     (java-mode
      "abstract" "assert" "boolean" "break" "byte" "case" "catch" "char" "class"
      "continue" "default" "do" "double" "else" "enum" "extends" "final"
@@ -224,10 +229,6 @@
      "then" "true" "undef" "unless" "until" "when" "while" "yield")
     ;; From https://doc.rust-lang.org/grammar.html#keywords
     ;; but excluding unused reserved words: https://www.reddit.com/r/rust/comments/34fq0k/is_there_a_good_list_of_rusts_keywords/cqucvnj
-    (go-mode
-     "break" "case" "chan" "const" "continue" "default" "defer" "else" "fallthrough"
-     "for" "func" "go" "goto" "if" "import" "interface" "map" "package" "range"
-     "return" "select" "struct" "switch" "type" "var")
     (rust-mode
      "Self"
      "as" "box" "break" "const" "continue" "crate" "else" "enum" "extern"


### PR DESCRIPTION
hi @dgutov , somedays ago, i added the golang's keywords to company-keywords.el, but it is updated, so i put them to the right place :)