### PR TITLE
Switch to npostavs/emacs-travis binaries for Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,23 @@
-sudo: false
-
 language: generic
 
-matrix:
-  include:
-    - env: EMACS=emacs24
-      addons:
-        apt:
-          sources: [ { sourceline: 'ppa:cassou/emacs' } ]
-          packages: [ emacs24, emacs24-el ]
-    - env: EMACS=emacs25
-      addons:
-        apt:
-          sources: [ { sourceline: 'ppa:kelleyk/emacs' } ]
-          packages: [ emacs25 ]
-    - env: EMACS=emacs-snapshot
-      addons:
-        apt:
-          sources: [ { sourceline: 'ppa:ubuntu-elisp/ppa' } ]
-          packages: [ emacs-snapshot ]
+sudo: false
 
-install: true
+env:
+  global:
+    - CURL="curl -fsSkL --retry 9 --retry-delay 9"
+  matrix:
+    - EMACS_VERSION=24.5
+    - EMACS_VERSION=25.3
+    - EMACS_VERSION=26.1
+    - EMACS_VERSION=master
+  allow_failures:
+    - env: EMACS_VERSION=master
+
+install:
+  - $CURL -O https://github.com/npostavs/emacs-travis/releases/download/bins/emacs-bin-${EMACS_VERSION}.tar.gz
+  - tar -xaf emacs-bin-${EMACS_VERSION}.tar.gz -C /
+  - export EMACS=/tmp/emacs/bin/emacs
+  - $EMACS --version
 
 script:
   make test-batch EMACS=${EMACS}


### PR DESCRIPTION
Supported versions are 24.5, 25.3, 26.1 and master.
master is allowed to be failed.

Resolves #805

Please feel free to close this if you are not in favor of it.