### PR TITLE
company: company--company-command-p: Fix lookup-key

### DIFF
--- a/company.el
+++ b/company.el
@@ -832,7 +832,7 @@ means that `company-mode' is always turned on except in `message-mode' buffers."
 (defun company--company-command-p (keys)
   "Checks if the keys are part of company's overriding keymap"
   (or (equal [company-dummy-event] keys)
-      (lookup-key company-my-keymap keys)))
+      (commandp (lookup-key company-my-keymap keys))))
 
 ;; Hack:
 ;; Emacs calculates the active keymaps before reading the event.  That means we


### PR DESCRIPTION
Make sure it returns an actual command.

`lookup-key` returns a number when the key sequence is longer than 1 but it
isn't a valid sequence of prefix characters. The number evaluates to true but
the key isn't in the keymap.

When that happens the completion gets lost. To reproduce, complete a variable
name and type C-x C-s to save.

Fixes #857

Reported-by: Thomas Fini Hansen <https://github.com/xendk>