### PR TITLE
Add Embarcadero clang-based compilers to company-clang-version

### DIFF
--- a/company-clang.el
+++ b/company-clang.el
@@ -297,7 +297,8 @@ or automatically through a custom `company-clang-prefix-guesser'."
   (with-temp-buffer
     (call-process company-clang-executable nil t nil "--version")
     (goto-char (point-min))
-    (if (re-search-forward "\\(clang\\|Apple LLVM\\) version \\([0-9.]+\\)" nil t)
+    (if (re-search-forward
+         "\\(clang\\|Apple LLVM\\|bcc32x\\|bcc64\\) version \\([0-9.]+\\)" nil t)
         (cons
          (if (equal (match-string-no-properties 1) "Apple LLVM")
              'apple


### PR DESCRIPTION
Embarcadero ships clang-based compilers with their C++ Builder IDE. Using `company-clang` with their compilers works surprisingly well, provided the changes in this PR are applied.

Example output of `bcc64 --version`:
~~~
Embarcadero C++ 7.40 for Win64 Copyright (c) 2012-2018 Embarcadero Technologies, Inc.
Embarcadero Technologies Inc. bcc64 version 3.3.1 (36707.161adda.9a76976) (based on LLVM 3.3.1)
~~~

