### PR TITLE
Use line-wrap in company doc buffer

### DIFF
--- a/company.el
+++ b/company.el
@@ -2271,7 +2271,8 @@ character, stripping the modifiers.  That character must be a digit."
     (erase-buffer)
     (when string
       (save-excursion
-        (insert string)))
+        (insert string)
+        (visual-line-mode)))
     (current-buffer)))
 
 (defvar company--electric-saved-window-configuration nil)


### PR DESCRIPTION
I had issues where long lines did not wrap in company-doc-buffer. I think this fixes it but this is my first time looking at company-modes code so feel free to criticize this all you want. 