### PR TITLE
Add custom variable to disable tramp-aware clang invocation

### DIFF
--- a/company-clang.el
+++ b/company-clang.el
@@ -76,6 +76,11 @@ or automatically through a custom `company-clang-prefix-guesser'."
   :type 'boolean
   :package-version '(company . "0.8.0"))
 
+(defcustom company-clang-use-remote-executable t
+  "When non-nil, clang will be run via tramp-aware call to `start-file-process' 
+instead of tramp-oblivious `start-process'."
+  :type 'boolean)
+
 ;; prefix ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defvar company-clang--prefix nil)
@@ -223,7 +228,9 @@ or automatically through a custom `company-clang-prefix-guesser'."
       (erase-buffer)
       (setq buffer-undo-list t))
     (let* ((process-connection-type nil)
-           (process (apply #'start-file-process "company-clang" buf
+           (start-process (if company-clang-use-remote-executable
+                              #'start-file-process #'start-process))
+           (process (apply start-process "company-clang" buf
                            company-clang-executable args)))
       (set-process-sentinel
        process


### PR DESCRIPTION
a2ec8062f7537110c10edcd2bfec6159b90a8495 added tramp awareness to the invocation of clang. However, it is not always desirable to run clang on the remote machine, particularly when clang is not on the remote machine. This adds the ability to use the tramp-oblivious invocation instead.