### PR TITLE
Add missing argument

### DIFF
--- a/company.el
+++ b/company.el
@@ -2957,7 +2957,7 @@ Returns a negative number if the tooltip should be displayed above point."
 
 (defun company-pseudo-tooltip-guard ()
   (list
-   (save-excursion (beginning-of-visual-line))
+   (save-excursion (beginning-of-visual-line 1))
    (window-width)
    (let ((ov company-pseudo-tooltip-overlay)
          (overhang (save-excursion (end-of-visual-line)


### PR DESCRIPTION
This function is failing for my emacs since it expects an argument for beginning-of-visual-line.

Here is the error that I was getting before changing this.
```
Company: An error occurred in post-command
Company: frontend company-pseudo-tooltip-unless-just-one-frontend error "Wrong number of arguments: #[(ad--addoit-function arg) "\306\211\307\310\306\"\211\203�
\203�\311\312!\204�\311\313!\203�\306!
\203\200�	\204\200�\314=\203\200�\315 \203\200�\316 \317 \320\211;\203O�\321\322#\266\202\202W�\323A@\"\266\202X\205]�\324  \325!\315!\203t�\326 \203t�\327\216\330 \210)+\307\310\306\"\204\200�\331\306w\210\"\203\274�#\203\274�	\204\274�$%>\204\274�&\203\241�\332\333!\203\274�\334 \204\274�'\204\274�\335 \203\270�\330 \210\307\310\306\"\210\331\306w\210))\207" [ad-return-value at-beginning auto-indent-home-is-beginning-of-indent-when-spaces-follow ad--addoit-function arg auto-indent-fix-org-move-beginning-of-line nil looking-back "^[ 	]*" looking-at "[ 	]*$" "[ 	]" org-mode org-babel-where-is-src-block-head org-element-at-point line-beginning-position :post-affiliated get-text-property 0 plist-get point-marker switch-invisibly org-edit-src-code #[nil "\301 \210\205	�b\207" [outside-position org-edit-src-exit] 1] auto-indent-according-to-mode " 	" called-interactively-p any auto-indent-remove-advice-p auto-indent-aggressive-p major-mode element outside-position org-src-window-setup auto-indent-home-is-beginning-of-indent auto-indent-mode indent-line-function auto-indent-disabled-indent-functions auto-indent-force-interactive-advices current-prefix-arg] 8], 1" on command post-command
```

Here is my emacs version 

```
GNU Emacs 26.3 (build 1, x86_64-apple-darwin18.2.0, NS appkit-1671.20 Version 10.14.3 (Build 18D109)) of 2019-09-02
```

I can replicate this error by evaluating 
```
(beginning-of-visual-line)
```