### PR TITLE
Fix Travis CI Build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: generic
 
-sudo: false
-
 env:
   global:
     - CURL="curl -fsSkL --retry 9 --retry-delay 9"
@@ -10,6 +8,8 @@ env:
     - EMACS_VERSION=25.3
     - EMACS_VERSION=26.1
     - EMACS_VERSION=master
+    
+matrix:
   allow_failures:
     - env: EMACS_VERSION=master
 


### PR DESCRIPTION
You can see Build config validation warnings in https://travis-ci.org/github/company-mode/company-mode/builds/656404873/config.

This PR silence them and correct `allow_failures:` config.