### PR TITLE
add the docbuffer on company-yasnippet

### DIFF
--- a/company-yasnippet.el
+++ b/company-yasnippet.el
@@ -97,6 +97,13 @@
        res))
    tables))
 
+(defun company-yasnippet--doc (arg)
+  (let ((template (get-text-property 0 'yas-template arg)))
+    (with-current-buffer (company-doc-buffer)
+      (insert (yas--template-content template))
+      (goto-char (point-min))
+      (current-buffer))))
+
 ;;;###autoload
 (defun company-yasnippet (command &optional arg &rest ignore)
   "`company-mode' backend for `yasnippet'.
@@ -134,6 +141,7 @@ shadow backends that come after it.  Recommended usages:
       (unless company-tooltip-align-annotations " -> ")
       (get-text-property 0 'yas-annotation arg)))
     (candidates (company-yasnippet--candidates arg))
+    (doc-buffer (company-yasnippet--doc arg))
     (no-cache t)
     (post-completion
      (let ((template (get-text-property 0 'yas-template arg))


### PR DESCRIPTION
Add the `docbuffer` on `company-yasnippet`.  Just a simple implementation, I think it can be  improve it by expand snippets in the docbuffer and using markdown render.

![image](https://user-images.githubusercontent.com/41671631/76700515-47729880-66f3-11ea-8c31-5225d83a734a.png)

