### PR TITLE
Improve the behavior

### DIFF
--- a/company-yasnippet.el
+++ b/company-yasnippet.el
@@ -107,11 +107,15 @@ It has to accept one argument: the snippet's name.")
 
 (defun company-yasnippet--doc (arg)
   (let ((template (get-text-property 0 'yas-template arg))
-        (mode major-mode))
+        (mode major-mode)
+        (file-name (buffer-file-name)))
     (with-current-buffer (company-doc-buffer)
-      (setq-local buffer-file-name "company-yasnippet-doc")
+      (setq-local buffer-file-name file-name)
       (yas-minor-mode 1)
-      (yas-expand-snippet (yas--template-content template))
+      (condition-case error
+        (yas-expand-snippet (yas--template-content template))
+       (error
+          (message "%s"  (error-message-string error))))
       (delay-mode-hooks
         (let ((inhibit-message t))
           (if (eq mode 'web-mode)

--- a/company-yasnippet.el
+++ b/company-yasnippet.el
@@ -109,6 +109,7 @@ It has to accept one argument: the snippet's name.")
   (let ((template (get-text-property 0 'yas-template arg))
         (mode major-mode))
     (with-current-buffer (company-doc-buffer)
+      (setq-local buffer-file-name "company-yasnippet-doc")
       (yas-minor-mode 1)
       (yas-expand-snippet (yas--template-content template))
       (delay-mode-hooks


### PR DESCRIPTION
## Summary
1. It will fix errors caused by snippets that use `file-name-base` function. The `file-name-base` will get the value of `file-name` or `buffer-file-name` . Set the `buffer-file-name` of `doc-buffer` to current file `buffer-file-name`.
2. Considering this situation, we need to catch the error without affecting the user's input, and output the error information to the `*Message*` buffer.

## Test snippet
* case 1
```
# -*- mode: snippet -*-
# name: template
# key: template
# --
;;; ${1:$$(file-name-base)}.el --- $2 -*- lexical-binding: t; -*-
;;; Time-stamp: <2020-02-02 17:37:34 stardiviner>
;;; Commentary:
$3
;;; Code:
$0
(provide '$1)
;;; $1.el ends here
```
* works fine
![image](https://user-images.githubusercontent.com/41671631/76837840-2aaea000-686e-11ea-9904-17a7b7a13711.png)

* case 2
Comment the `buffer-file-name` , We will got an error then catch error and output to `*Message*` buffer.  but `company-yasnippet` also work fine. 
![image](https://user-images.githubusercontent.com/41671631/76838280-f7b8dc00-686e-11ea-9720-15a170523a5b.png)

error on `*Message*` buffer. It does not appear to disturb the user's input.
![image](https://user-images.githubusercontent.com/41671631/76838369-11f2ba00-686f-11ea-9e71-a3213b372059.png)






