### PR TITLE
[company-files] Make post-completion command a dedicated function

### DIFF
--- a/company-files.el
+++ b/company-files.el
@@ -127,6 +127,10 @@ The values should use the same format as `completion-ignored-extensions'."
   (and (equal (cdr old) (cdr new))
        (string-prefix-p (car old) (car new))))
 
+(defun company-files--post-completion (arg)
+  (when (company-files--trailing-slash-p arg)
+    (delete-char -1)))
+
 ;;;###autoload
 (defun company-files (command &optional arg &rest ignored)
   "`company-mode' completion backend existing file names.
@@ -139,8 +143,7 @@ File paths with spaces are only supported inside strings."
     (candidates (company-files--complete arg))
     (location (cons (dired-noselect
                      (file-name-directory (directory-file-name arg))) 1))
-    (post-completion (when (company-files--trailing-slash-p arg)
-                       (delete-char -1)))
+    (post-completion (company-files--post-completion arg))
     (sorted t)
     (no-cache t)))
 


### PR DESCRIPTION
[company-files] Make post-completion command a dedicated function so that it can be advised easier (e.g: delete file extension on completion).

Signed-off-by: Huy Duong <huy.duong@employmenthero.com>