### PR TITLE
Set tooltip background color for terminals with less than 88 colors

### DIFF
--- a/company.el
+++ b/company.el
@@ -90,7 +90,7 @@ attention to case differences."
   :group 'faces)
 
 (defface company-tooltip
-  '((default :foreground "black")
+  '((default :foreground "black" :background "yellow")
     (((class color) (min-colors 88) (background light))
      (:background "cornsilk"))
     (((class color) (min-colors 88) (background dark))


### PR DESCRIPTION
Related issue: #380 -- The screenshot on the first comment describes the issue fixed by this patch.

The current implementation specifies the foreground color for tooltips to be black but does not gives the background color on terminals with less color capability, which causes invisible text when the background is black on <88-color terminals.

This patch fixes the problem by giving a default background color. This change does not affect >=88-color terminals.

I believe many people use 256-color terminals or true-color GUI nowadays, but I use an 8-color terminal and want every Emacs package to have a usable default color on it...