### PR TITLE
Fix company--face-attribute helper

### DIFF
--- a/company.el
+++ b/company.el
@@ -2750,13 +2750,17 @@ If SHOW-VERSION is non-nil, show the version in the echo area."
   ;; Like `face-attribute', but accounts for faces that have been remapped to
   ;; another face, a list of faces, or a face spec.
   (cond ((symbolp face)
-         (let ((remap (cadr (assq face face-remapping-alist))))
+         (let ((remap (cdr (assq face face-remapping-alist))))
            (if remap
-               (company--face-attribute remap attr)
+               (company--face-attribute
+                ;; Faces can be remapped to their unremapped selves, but that
+                ;; would cause us infinite recursion.
+                (if (listp remap) (remq face remap) remap)
+                attr)
              (face-attribute face attr nil t))))
         ((keywordp (car-safe face))
          (or (plist-get face attr)
-             (company--face-attribute (plist-get face :inherit))))
+             (company--face-attribute (plist-get face :inherit) attr)))
         ((listp face)
          (cl-find-if #'stringp
                      (mapcar (lambda (f) (company--face-attribute f attr))


### PR DESCRIPTION
Fixes three cases:

1. When FACE is remapped to a single face in face-remapping-alist (which fixes #1022).
2. When FACE remapped to a list of faces (and potentially contains a self-reference, which face-remap allows so faces can refer to their pre-remapped selves).
3. When FACE is a face spec, a missing argument would've caused a wrong-number-of-args error.

Note: I've submitted my FSF CA (thanks for that by the way). Still waiting to hear back.

EDIT: Corrected typo in comment.