### PR TITLE
Implement `company-select-first' and `company-select-last'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+* New commands `company-select-first` and `company-select-last`.
 * `company-tng-mode` has been added to replace both
   `company-tng-configure-default` and the manual method of enabling
   `company-tng-frontend` (see also `company-tng-auto-configure`). Also,

--- a/company.el
+++ b/company.el
@@ -2098,6 +2098,16 @@ With ARG, move by that many elements."
     (company-abort)
     (company--unread-this-command-keys)))
 
+(defun company-select-first ()
+  "Select the first completion candidate."
+  (interactive)
+  (company-set-selection 0))
+
+(defun company-select-last ()
+  "Select the last completion candidate."
+  (interactive)
+  (company-set-selection (1- company-candidates-length)))
+
 (defun company-next-page ()
   "Select the candidate one page further."
   (interactive)


### PR DESCRIPTION
I think it's worth having these two functions so users can bind `M-<` (which is usually `beginning-of-buffer`) to `company-select-first` and `M->` (which is usually `end-of-buffer`) to `company-select-last`.