### PR TITLE
Capf backends can specify :company-cache to turn on cache

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,11 @@
   users these days, with
   ([emacs-eclim](https://github.com/emacs-eclim/emacs-eclim/)) declared obsolete
   in favor of `lsp-java`. Though it used its own backend anyway.
+* The `company-capf` backend will pick up on a `:company-cache` metadata element
+  on the capf function (similar to `:company-location` or `:company-doc-buffer`)
+  and use it to control caching behaviour.  The new element's value can be set
+  to non-nil if the capf function ensures it supplies the full set of candidates
+  regardless of prefix.
 
 ## 2020-07-26 (0.9.13)
 

--- a/company-capf.el
+++ b/company-capf.el
@@ -133,8 +133,12 @@ so we can't just use the preceding variable instead.")
                     (setq match-start nil))))
            (nreverse chunks)))))
     (`duplicates t)
-    (`no-cache t)   ;Not much can be done here, as long as we handle
-                    ;non-prefix matches.
+    (`no-cache
+     ;; since we eventually handle non-prefix matches, we're no-cache by
+     ;; default, unless the backend declares it's giving us the full set by
+     ;; setting a flag.
+     (null (plist-get (nthcdr 4 company-capf--current-completion-data)
+                      :company-cache)))
     (`meta
      (let ((f (plist-get (nthcdr 4 company-capf--current-completion-data)
                          :company-docsig)))


### PR DESCRIPTION
This is useful for capf backends who can calculate the full set of completions
regardless of the prefix, such as when completing property names on Javascript
objects.

* NEWS.md: Mention :company-cache.

* company-capf.el (company-capf): Pick on on :company-cache.