### PR TITLE
Refine company-gtags--annotation regexp

### DIFF
--- a/company-gtags.el
+++ b/company-gtags.el
@@ -116,7 +116,7 @@ completion."
 
 (defun company-gtags--annotation (arg)
   (let ((meta (get-text-property 0 'meta arg)))
-    (when (string-match (concat (regexp-quote arg) "\\((.*)\\).*") meta)
+    (when (string-match (concat (regexp-quote arg) "\\(([^\)]*)\\).*") meta)
       (match-string 1 meta))))
 
 ;;;###autoload

--- a/test/gtags-tests.el
+++ b/test/gtags-tests.el
@@ -1,0 +1,55 @@
+;;; gtags-tests.el --- company-mode tests  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2020  Free Software Foundation, Inc.
+
+;; Author: Aymeric Agon-Rambosson
+
+;; This file is part of GNU Emacs.
+
+;; GNU Emacs is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+
+(require 'company-tests)
+(require 'company-gtags)
+
+(ert-deftest company-gtags-cpp-macro-variable ()
+  (let ((str (propertize
+	      "PGT_ADDRESS_MASK"
+	      'meta "#define PGT_ADDRESS_MASK 0xFFFFFFFFFF000")))
+    (should (null (company-gtags 'annotation str)))))
+
+(ert-deftest company-gtags-cpp-macro-function ()
+  (let ((str (propertize
+	      "ADDRESS_FROM_STACK"
+	      'meta "#define ADDRESS_FROM_STACK(a) ((TEXT_BASE > a) && (a >= STACK_BASE))")))
+    (should (equal (company-gtags 'annotation str)
+		   "(a)"))))
+
+(ert-deftest company-gtags-C-function ()
+  (let ((str (propertize
+	      "munmap"
+	      'meta "void munmap(struct task *ctx, vaddr_t vaddr)")))
+    (should (equal (company-gtags 'annotation str)
+		   "(struct task *ctx, vaddr_t vaddr)"))))
+
+(ert-deftest company-gtags-C-type ()
+  (let ((str (propertize
+	      "uint64_t"
+	      'meta "typedef unsigned long int   uint64_t;")))
+    (should (null (company-gtags 'annotation str)))))
+
+(ert-deftest company-gtags-C-struct ()
+  (let ((str (propertize
+	      "interrupt_context"
+	      'meta "struct interrupt_context")))
+    (should (null (company-gtags 'annotation str)))))

--- a/test/gtags-tests.el
+++ b/test/gtags-tests.el
@@ -1,6 +1,6 @@
 ;;; gtags-tests.el --- company-mode tests  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2020  Free Software Foundation, Inc.
+;; Copyright (C) 2021  Free Software Foundation, Inc.
 
 ;; Author: Aymeric Agon-Rambosson
 


### PR DESCRIPTION
Replacing company-gtags--annotation greedy regexp with the lazy version to make company-gtags behave better with C preprocessor macro-functions.