### PR TITLE
Fix README.md link to homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-See the [homepage](http://company-mode.github.com/).
+See the [homepage](http://company-mode.github.io/).
 
 [![Build Status](https://travis-ci.org/company-mode/company-mode.png?branch=master)](https://travis-ci.org/company-mode/company-mode)
 [![MELPA](https://melpa.org/packages/company-badge.svg)](https://melpa.org/#/company)


### PR DESCRIPTION
http://company-mode.github.com 404s and suggests http://company-mode.github.io, as the .com version of GitHub pages had been deprecated and stopped redirecting yesterday.