### PR TITLE
Improve default colors for dark themes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+* Change default colors for dark themes ([#949](https://github.com/company-mode/company-mode/issues/949)).
 * Default key bindings have been changed, moving `company-select-next` and
   `company-select-previous` from `M-n` and `M-p` to `C-n` and `C-p`
   ([#1098](https://github.com/company-mode/company-mode/pull/1098)). The

--- a/company.el
+++ b/company.el
@@ -77,20 +77,18 @@
   :group 'faces)
 
 (defface company-tooltip
-  '((default :foreground "black")
-    (((class color) (min-colors 88) (background light))
-     (:background "cornsilk"))
+  '((((class color) (min-colors 88) (background light))
+     (:foreground "black" :background "cornsilk"))
     (((class color) (min-colors 88) (background dark))
-     (:background "yellow"))
-    (t
-     (:background "yellow")))
+     (:background "gray26"))
+    (t (:foreground "black" :background "yellow")))
   "Face used for the tooltip.")
 
 (defface company-tooltip-selection
   '((((class color) (min-colors 88) (background light))
      (:background "light blue"))
     (((class color) (min-colors 88) (background dark))
-     (:background "orange1"))
+     (:background "gray31"))
     (t (:background "green")))
   "Face used for the selection in the tooltip.")
 
@@ -110,7 +108,7 @@
   '((((background light))
      :foreground "darkred")
     (((background dark))
-     :foreground "red"))
+     :foreground "pale turquoise"))
   "Face used for the common completion in the tooltip.")
 
 (defface company-tooltip-common-selection
@@ -121,7 +119,7 @@
   '((((background light))
      :foreground "firebrick4")
     (((background dark))
-     :foreground "red4"))
+     :foreground "LightCyan3"))
   "Face used for the completion annotation in the tooltip.")
 
 (defface company-tooltip-annotation-selection
@@ -132,38 +130,26 @@
   '((((background light))
      :background "darkred")
     (((background dark))
-     :background "red"))
+     :background "gray33"))
   "Face used for the tooltip scrollbar thumb.")
 
 (defface company-scrollbar-bg
   '((((background light))
      :background "wheat")
     (((background dark))
-     :background "gold"))
+     :background "gray28"))
   "Face used for the tooltip scrollbar background.")
 
 (defface company-preview
-  '((((background light))
-     :inherit (company-tooltip-selection company-tooltip))
-    (((background dark))
-     :background "blue4"
-     :foreground "wheat"))
+  '((default :inherit (company-tooltip-selection company-tooltip)))
   "Face used for the completion preview.")
 
 (defface company-preview-common
-  '((((background light))
-     :inherit company-tooltip-common-selection)
-    (((background dark))
-     :inherit company-preview
-     :foreground "red"))
+  '((default :inherit company-tooltip-common-selection))
   "Face used for the common part of the completion preview.")
 
 (defface company-preview-search
-  '((((background light))
-     :inherit company-tooltip-common-selection)
-    (((background dark))
-     :inherit company-preview
-     :background "blue1"))
+  '((default :inherit company-tooltip-common-selection))
   "Face used for the search string in the completion preview.")
 
 (defface company-echo nil


### PR DESCRIPTION
Closes #949

<img width="593" alt="1-manoj-dark" src="https://user-images.githubusercontent.com/296460/118130403-fc8f0680-b405-11eb-8315-d3107c4e70cd.png">
<img width="581" alt="2-wheatgrass" src="https://user-images.githubusercontent.com/296460/118130438-06b10500-b406-11eb-9242-294752608f5a.png">
<img width="588" alt="3-deeper-blue" src="https://user-images.githubusercontent.com/296460/118130444-07499b80-b406-11eb-9b15-529a56f7af85.png">
<img width="584" alt="4-wombat" src="https://user-images.githubusercontent.com/296460/118130445-07e23200-b406-11eb-8cc5-eb2a3d75e9dc.png">
<img width="575" alt="5-tsdh-dark" src="https://user-images.githubusercontent.com/296460/118130447-07e23200-b406-11eb-8f22-ccf29023bb54.png">
<img width="586" alt="6-tsdh-dark" src="https://user-images.githubusercontent.com/296460/118130448-087ac880-b406-11eb-93d5-930865804052.png">
<img width="596" alt="7-misterioso" src="https://user-images.githubusercontent.com/296460/118130449-087ac880-b406-11eb-82ac-1bec2cecb5c8.png">
<img width="241" alt="preview-wombat" src="https://user-images.githubusercontent.com/296460/118130451-087ac880-b406-11eb-9849-63fb4acb353c.png">
