### PR TITLE
Add faces for quick-access numbers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+* New faces `company-tooltip-quick-access` and
+  `company-tooltip-quick-access-selection`
+  ([#303](https://github.com/company-mode/company-mode/issues/303)).
 * Default colors for dark themes have been changed
   ([#949](https://github.com/company-mode/company-mode/issues/949)).
 * Default key bindings have been changed, moving `company-select-next` and

--- a/company.el
+++ b/company.el
@@ -126,6 +126,16 @@
   '((default :inherit company-tooltip-annotation))
   "Face used for the selected completion annotation in the tooltip.")
 
+(defface company-tooltip-quick-access
+  '((default :inherit company-tooltip-annotation))
+  "Face used for the quick-access keys shown in the tooltip."
+  :package-version '(company . "0.9.14"))
+
+(defface company-tooltip-quick-access-selection
+  '((default :inherit company-tooltip-annotation-selection))
+  "Face used for the selected quick-access keys shown in the tooltip."
+  :package-version '(company . "0.9.14"))
+
 (defface company-scrollbar-fg
   '((((background light))
      :background "darkred")
@@ -2993,6 +3003,14 @@ If SHOW-VERSION is non-nil, show the version in the echo area."
                     (mod numbered 10)
                   " ")))
 
+(defun company--format-quick-access-key (numbered selected)
+  "Produce a quick-access key to show beside a candidate."
+  (propertize (funcall company-show-numbers-function numbered)
+              'face
+              (if selected
+                  'company-tooltip-quick-access-selection
+                'company-tooltip-quick-access)))
+
 (defsubst company--window-height ()
   (if (fboundp 'window-screen-lines)
       (floor (window-screen-lines))
@@ -3180,18 +3198,18 @@ If SHOW-VERSION is non-nil, show the version in the echo area."
                (annotation (cadr item))
                (left (nth 2 item))
                (right (company-space-string company-tooltip-margin))
-               (width width))
+               (width width)
+               (selected (equal selection i)))
           (when company-show-numbers
-            (let ((numbers-place
-                   (gv-ref (if (eq company-show-numbers 'left) left right))))
-            (cl-decf width 2)
-            (cl-incf numbered)
-            (setf (gv-deref numbers-place)
-                  (concat (funcall company-show-numbers-function numbered)
-                          (gv-deref numbers-place)))))
+            (let ((numbers-place (gv-ref (if (eq company-show-numbers 'left) left right))))
+              (cl-decf width 2)
+              (cl-incf numbered)
+              (setf (gv-deref numbers-place)
+                    (concat (company--format-quick-access-key numbered selected)
+                            (gv-deref numbers-place)))))
           (push (concat
                  (company-fill-propertize str annotation
-                                          width (equal i selection)
+                                          width selected
                                           left
                                           right)
                  (when scrollbar-bounds


### PR DESCRIPTION
Closes #303.

@dgutov Hi Dmitry, please review the suggested changes.

Built-in **leuven** theme, having customized Company faces, is a representative example:
<img width="604" alt="leuven" src="https://user-images.githubusercontent.com/296460/118482903-08d4d580-b71e-11eb-8ace-366f60eefc59.png">


I've got two more - aside - concerns:

1. The term `numbers` stands for the representation, so `quick-access` (action) or `candidate-id` (entity) could potentially be a better choice. `(defface company-tooltip-quck-access)` or similar perhaps could provide better context to what the face - and functionality overall - does. **But**, the term is used throughout the code, so had to stick with the `numbers`.
The term may also lead to confusion when first met, such as "Which numbers? Numbers of occurrences maybe? Or numbers in the candidates? Or the numbers I type? ... etc".

2. I was confused to find `company--show-numbers` function under `;; replace` section caption. Should `company--show-numbers` and the suggested by this PR `company--show-numbers-propertize` be moved to another location?
  