### PR TITLE
Replace term number(s) by term quick-access

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## Next
 
+* Variables and functions related to the quick-access functionality
+  have been renamed as follows:
+  - `company-show-numbers` to `company-show-quick-access`
+  - `company-show-numbers-function` to `company-quick-access-key-producer`
+  - `company-complete-number` to `company-complete-quick-access`
+  - `company--show-numbers` to `company-quick-access-digit`.
+  ([#1103](https://github.com/company-mode/company-mode/pull/1103)).
 * Default colors for dark themes have been changed
   ([#949](https://github.com/company-mode/company-mode/issues/949)).
 * Default key bindings have been changed, moving `company-select-next` and

--- a/test/frontends-tests.el
+++ b/test/frontends-tests.el
@@ -131,24 +131,24 @@
           (should (string= (overlay-get ov 'company-display)
                            " 123     (4) \n 45          \n 67 (891011) \n")))))))
 
-(ert-deftest company-create-lines-shows-numbers ()
-  (let ((company-show-numbers t)
+(ert-deftest company-create-lines-shows-quick-access ()
+  (let ((company-show-quick-access t)
         (company-candidates '("x" "y" "z"))
         (company-candidates-length 3)
         (company-backend 'ignore))
     (should (equal '(" x 1 " " y 2 " " z 3 ")
                    (cdr (company--create-lines 0 999))))))
 
-(ert-deftest company-create-lines-shows-numbers-on-the-left ()
-  (let ((company-show-numbers 'left)
+(ert-deftest company-create-lines-shows-quick-access-on-the-left ()
+  (let ((company-show-quick-access 'left)
         (company-candidates '("x" "y" "z"))
         (company-candidates-length 3)
         (company-backend 'ignore))
     (should (equal '(" 1 x " " 2 y " " 3 z ")
                    (cdr (company--create-lines 0 999))))))
 
-(ert-deftest company-create-lines-combines-numbers-on-the-left-and-icons ()
-  (let ((company-show-numbers 'left)
+(ert-deftest company-create-lines-combines-quick-access-on-the-left-and-icons ()
+  (let ((company-show-quick-access 'left)
         (company-candidates '("x" "y" "z"))
         (company-format-margin-function (lambda (candidate selected)
                                           "X"))
@@ -219,7 +219,7 @@
 
 (ert-deftest company-create-lines-clears-out-non-printables ()
   :tags '(interactive)
-  (let (company-show-numbers
+  (let (company-show-quick-access
         (company-candidates (list
                              (decode-coding-string "avalis\351e" 'utf-8)
                              "avatar"))
@@ -231,7 +231,7 @@
 
 (ert-deftest company-create-lines-handles-multiple-width ()
   :tags '(interactive)
-  (let (company-show-numbers
+  (let (company-show-quick-access
         (company-candidates '("蛙蛙蛙蛙" "蛙abc"))
         (company-candidates-length 2)
         (company-backend 'ignore))
@@ -240,7 +240,7 @@
                    (cdr (company--create-lines 0 999))))))
 
 (ert-deftest company-create-lines-handles-multiple-width-in-annotation ()
-  (let* (company-show-numbers
+  (let* (company-show-quick-access
          (alist '(("a" . " ︸") ("b" . " ︸︸")))
          (company-candidates (mapcar #'car alist))
          (company-candidates-length 2)
@@ -253,7 +253,7 @@
 
 (ert-deftest company-create-lines-with-multiple-width-and-keep-prefix ()
   :tags '(interactive)
-  (let* (company-show-numbers
+  (let* (company-show-quick-access
          (company-candidates '("MIRAI発売1カ月"
                                "MIRAI発売2カ月"))
          (company-candidates-length 2)
@@ -266,7 +266,7 @@
                    (cdr (company--create-lines 0 999))))))
 
 (ert-deftest company-create-lines-with-format-function ()
-  (let* (company-show-numbers
+  (let* (company-show-quick-access
          (company-candidates '("ArrayList"))
          (company-candidates-length 1)
          (company-tooltip-maximum-width 7)
@@ -282,7 +282,7 @@
 
 (ert-deftest company-create-lines-with-icons-format-function ()
   :tags '(gui)
-  (let* (company-show-numbers
+  (let* (company-show-quick-access
          (company-icon-size 15)
          (company-candidates '("ArrayList"))
          (company-candidates-length 1)


### PR DESCRIPTION
#1103, #188

@dgutov Dmitry, your input is very welcome!

This is more of a WIP than an actual PR at this stage: I'm still working on possibly providing `M-(letter)` as one of the easily chosen package options. If I find a way to provide it *nicely*, then highly possible `company-quick-access-key-producer` and `company-quick-access-digit` (maybe others) would have to be changed again.

So please let me know if you see any issues with the suggested changes. (I don't like to introduce many breaking changes, but obsoletes declarations seem to be a quite comfortable approach.)
Thanks.
 