### PR TITLE
Change echo-common face for light themes

### DIFF
--- a/company.el
+++ b/company.el
@@ -156,8 +156,8 @@
   "Face used for completions in the echo area.")
 
 (defface company-echo-common
-  '((((background dark)) (:foreground "firebrick1"))
-    (((background light)) (:background "firebrick4")))
+  '((((background light)) (:foreground "firebrick4"))
+    (((background dark)) (:foreground "firebrick1")))
   "Face used for the common part of completions in the echo area.")
 
 ;; Too lazy to re-add :group to all defcustoms down below.


### PR DESCRIPTION
Improves visibility of common part(s) of completions with echo-frontends for all built-in light themes.
**before**
<img width="350" alt="before" src="https://user-images.githubusercontent.com/296460/119855171-5d483400-bf1a-11eb-8440-edfc8836348c.png">
**after**
<img width="351" alt="after" src="https://user-images.githubusercontent.com/296460/119855195-60dbbb00-bf1a-11eb-967e-8fb2dd1c6c1e.png">

(And transposes the light/dark theme lines to match the order used by the rest of the deffaces.)