### PR TITLE
Fix quick-access column formatting

### DIFF
--- a/company.el
+++ b/company.el
@@ -2987,7 +2987,9 @@ If SHOW-VERSION is non-nil, show the version in the echo area."
           (company-safe-substring old (+ offset (length new)))))
 
 (defun company--show-numbers (numbered)
-  (format " %d" (mod numbered 10)))
+  (format " %s" (if (<= numbered 10)
+                    (mod numbered 10)
+                  " ")))
 
 (defsubst company--window-height ()
   (if (fboundp 'window-screen-lines)
@@ -3177,7 +3179,7 @@ If SHOW-VERSION is non-nil, show the version in the echo area."
                (left (nth 2 item))
                (right (company-space-string company-tooltip-margin))
                (width width))
-          (when (< numbered 10)
+          (when company-show-numbers
             (cl-decf width 2)
             (cl-incf numbered)
             (setf (if (eq company-show-numbers 'left) left right)


### PR DESCRIPTION
Do not break quick-access column when `company-tooltip-limit` > 10.

**before**
<img width="221" alt="left-before" src="https://user-images.githubusercontent.com/296460/120524276-903d6c80-c3df-11eb-8c20-88ae5636e8ec.png">
**after**
<img width="232" alt="left-after" src="https://user-images.githubusercontent.com/296460/120524288-92073000-c3df-11eb-8078-76b0ef33e893.png">

**before**
<img width="161" alt="right-before" src="https://user-images.githubusercontent.com/296460/120524301-96334d80-c3df-11eb-8e03-ef3263a6d6f6.png">
**after**
<img width="166" alt="right-after" src="https://user-images.githubusercontent.com/296460/120524312-9895a780-c3df-11eb-8b44-8685bc536c62.png">
