### PR TITLE
Improve readability by minor refactoring

### DIFF
--- a/company.el
+++ b/company.el
@@ -3180,11 +3180,13 @@ If SHOW-VERSION is non-nil, show the version in the echo area."
                (right (company-space-string company-tooltip-margin))
                (width width))
           (when company-show-numbers
+            (let ((numbers-place
+                   (gv-ref (if (eq company-show-numbers 'left) left right))))
             (cl-decf width 2)
             (cl-incf numbered)
-            (setf (if (eq company-show-numbers 'left) left right)
+            (setf (gv-deref numbers-place)
                   (concat (funcall company-show-numbers-function numbered)
-                          (if (eq company-show-numbers 'left) left right))))
+                          (gv-deref numbers-place)))))
           (push (concat
                  (company-fill-propertize str annotation
                                           width (equal i selection)


### PR DESCRIPTION
Initially suggested in #1103.

This is a minor change, and somewhat arguable. But I still remember being confused by the related piece of the code when reading it in the package for the first time, so would be pleased to see it improved, even if a bit. (Though not opposed with any scenario.)

Just in case,
I also tried (and learned a lot from it) to do something in the spirit of this snippet:
```
(dotimes (i 5)
  (let* ((left (format "left is %s" i))
         (place 'left))
    (set (symbol-value 'place)
         (format "i is %s + %s" i (symbol-value place)))
    (message "%s" left)))
```
But couldn't make it work in company.el without an error.

The following snippet corresponds to this PR's code change and works equally to the previous one in *scratch*.
```
(dotimes (i 5)
  (let* ((left (format "left is %s" i))
         (place (gv-ref left)))
    (setf (gv-deref place)
         (format "i is %s + %s" i (gv-deref place)))
    (message "%s" left)))
```