### PR TITLE
Rename and document company-complete-number

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+* `company-complete-number` declared obsolete in favor of
+   `company-complete-tooltip-row`
+  ([#1118](https://github.com/company-mode/company-mode/pull/1118)).
 * New faces `company-tooltip-quick-access` and
   `company-tooltip-quick-access-selection`
   ([#303](https://github.com/company-mode/company-mode/issues/303)).


### PR DESCRIPTION
[Initially discussed in #1104.](https://github.com/company-mode/company-mode/pull/1104#issuecomment-851591903)

Main points and questions:

- I could eventually test keypad behavior (hurray!) and got these results on Company's master:
  - `M-<kp-%d>` completes candidates both with *active-map* and *search-map*.
  - `<kp-%d>` does not. Since *search-map* explicitly binds `<kp-%d>` to print numbers, I suppose it'd be quite natural to intent `<kp-%d>` to work the same way with *active-map*.
  - Related commit: 43756857.

- #177 evil mode compatibility is still a question. (But `company-complete-number` is still in the code.)

- In the code, I had to put `company--add-quick-access-keys` function definition before its invocation.
With the definition located after invocation, I've spent hours trying to make it work with funcall/quoting, but got either *a la* "Symbol's function definition is void" errors or no bindings. I suppose the underlying concepts are not fully clear to me yet. Could you hint me how to fix this issue?

- If there's no restricting conventions or use-cases, maybe rather use `company--bind-quick-access-keys`? (With probably `company--unbind-quick-access-keys` counterpart according to what you'd suggested before.)

- `company--add-quick-access-keys` doc string is planned to be extended after keys customization is fully implemented. Actually, this commit could be stabilized but postponed for merge, used as a (at least mostly) certain foundation for the next layers of quick-access related changes. Please let me know what would be a preferred approach.

- Moved `company-active-map` to `;;; keymaps` section to have related definitions closer to each other. (Could be a separate commit for better clarity of the changes history.)

Thanks!
