### PR TITLE
Fix width of tooltip offset lines number display

### DIFF
--- a/company.el
+++ b/company.el
@@ -3172,7 +3172,7 @@ If SHOW-VERSION is non-nil, show the version in the echo area."
           (numbered (if company-show-numbers 0 99999))
           new)
       (when previous
-        (push (company--scrollpos-line previous width) new))
+        (push (company--scrollpos-line previous width left-margin-size) new))
 
       (dotimes (i len)
         (let* ((item (pop items))
@@ -3199,7 +3199,7 @@ If SHOW-VERSION is non-nil, show the version in the echo area."
                 new)))
 
       (when remainder
-        (push (company--scrollpos-line remainder width) new))
+        (push (company--scrollpos-line remainder width left-margin-size) new))
 
       (cons
        left-margin-size
@@ -3218,10 +3218,10 @@ If SHOW-VERSION is non-nil, show the version in the echo area."
                   'company-scrollbar-fg
                 'company-scrollbar-bg)))
 
-(defun company--scrollpos-line (text width)
+(defun company--scrollpos-line (text width right-margin-width)
   (propertize (concat (company-space-string company-tooltip-margin)
                       (company-safe-substring text 0 width)
-                      (company-space-string company-tooltip-margin))
+                      (company-space-string right-margin-width))
               'face 'company-tooltip))
 
 ;; show


### PR DESCRIPTION
The issue is visible with `(setq company-tooltip-offset-display 'lines)` and non-nil `company-format-margin-function`.
BTW, this `'lines` feature is a very nice one.

**before**
<img width="327" alt="lines-before" src="https://user-images.githubusercontent.com/296460/121923930-180e6980-cd44-11eb-870b-1f2340924ab8.png">
**after**
<img width="337" alt="lines-after" src="https://user-images.githubusercontent.com/296460/121923940-1a70c380-cd44-11eb-981e-f31f5e512b17.png">
