### PR TITLE
Mention just enabled Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-See the [homepage](http://company-mode.github.io/).
+[Installation and Usage](http://company-mode.github.io/).
+
+[File a Bug Report](https://github.com/company-mode/company-mode/issues).
+
+[Ask a Question](https://github.com/company-mode/company-mode/discussions/1).
+
+[Suggest a Feature](https://github.com/company-mode/company-mode/discussions/categories/ideas).
 
 [![Build Status](https://travis-ci.org/company-mode/company-mode.png?branch=master)](https://travis-ci.org/company-mode/company-mode)
 [![MELPA](https://melpa.org/packages/company-badge.svg)](https://melpa.org/#/company)


### PR DESCRIPTION
Discussed in #1134.

See example of a pinned [Before Asking a Question](https://github.com/yugaego/tmp/discussions). 

Updated `README.md` may serve as a replacement to an earlier suggested `Question / Feature Request` one-entry-point issue template, that provided a link to `Discussions`. 

Note that `Ask a Question` currently links to the 1st post in the Discussions. This would work fine if the first post would have a content such as:

```
#### Before asking a question
1. Read [installation and usage information](http://company-mode.github.io).
2. Read `C-h f company-mode` documentation.
3. Review [Wiki articles](https://github.com/company-mode/company-mode/wiki/Tips-&-tricks).
4. Search in [existing issues](https://github.com/company-mode/company-mode/issues?q=) and [discussions](https://github.com/yugaego/tmp/discussions).

Post [third-party packages](https://github.com/company-mode/company-mode/wiki/Third-Party-Packages) questions to the maintainers of the respective packages.

If you have **general `Emacs` questions**
1. Consult `C-h r` Emacs manual.
2. Search on [EmacsWiki](https://www.emacswiki.org/emacs), [Reddit](https://www.reddit.com/r/emacs/), [Emacs.SE](https://emacs.stackexchange.com).
3. Send an email to the [help-gnu-emacs](https://lists.gnu.org/mailman/listinfo/help-gnu-emacs) mailing list.
```