### PR TITLE
Fix link to Discussions QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [File a bug report](https://github.com/company-mode/company-mode/issues)
 
-[Ask a question](https://github.com/company-mode/company-mode/discussions/1)
+[Ask a question](https://github.com/company-mode/company-mode/discussions/categories/q-a)
 
 [Suggest a feature](https://github.com/company-mode/company-mode/discussions/categories/ideas)
 


### PR DESCRIPTION
In #1137 I also mentioned some other possible minor text updates.
But eventually, the current `Readme` seems to be fine to me (as more concise).

Just in case, I'm attaching here what I also considered for `Readme`:

Read [installation and usage](http://company-mode.github.io/) instructions.

File a bug report in [Issues](https://github.com/company-mode/company-mode/issues).

Ask a question or suggest a feature in [Discussions](https://github.com/company-mode/company-mode/discussions).

