### PR TITLE
Add company-tooltip-offset docstring

### DIFF
--- a/company.el
+++ b/company.el
@@ -2933,7 +2933,10 @@ If SHOW-VERSION is non-nil, show the version in the echo area."
 
 (defvar-local company-pseudo-tooltip-overlay nil)
 
-(defvar-local company-tooltip-offset 0)
+(defvar-local company-tooltip-offset 0
+  "Current scrolling state of the tooltip.
+Represented by the index of the first visible completion candidate
+from the candidates list.")
 
 (defvar-local company--tooltip-current-width 0)
 


### PR DESCRIPTION
The variable `company-tooltip-offset` was confusing when I was working on one of the previous changes.
An [explanation](https://github.com/company-mode/company-mode/pull/1104#issuecomment-853479362) was provided at that time. This PR adds a docstring to clarify the variable's role.

Additionally, may I suggest the removal of the following variables?
(I understand we declare them here and them assign default values later with `defvar-local` but still, it looks like as a not-needed duplication to my eye, that forced me double think why it is so and where should I put the docstring).

```
(defvar company-pseudo-tooltip-overlay)
(defvar company-tooltip-offset)
```

It's git-logged these `defvar`s were added to fix compilation errors, but I got no compilation errors after removing them (possibly I didn't reproduce some other conditions).

Optionally, could corresponding `defvar-local` be re-located, replacing `defvar`s under the question?
Thus these variables would be declared/assigned a value at once, but earlier in the code.

Please let me know if I miss something.

Thank you.
