### PR TITLE
Merge variables declaration and assignment

### DIFF
--- a/company.el
+++ b/company.el
@@ -2526,24 +2526,6 @@ With ARG, move by that many elements."
         (company-set-selection (- company-selection
                                   company-tooltip-limit))))))
 
-(defvar company-pseudo-tooltip-overlay)
-
-(defvar company-tooltip-offset)
-
-(defun company--inside-tooltip-p (event-col-row row height)
-  (let* ((ovl company-pseudo-tooltip-overlay)
-         (column (overlay-get ovl 'company-column))
-         (width (overlay-get ovl 'company-width))
-         (evt-col (car event-col-row))
-         (evt-row (cdr event-col-row)))
-    (and (>= evt-col column)
-         (< evt-col (+ column width))
-         (if (> height 0)
-             (and (> evt-row row)
-                  (<= evt-row (+ row height) ))
-           (and (< evt-row row)
-                (>= evt-row (+ row height)))))))
-
 (defun company--event-col-row (event)
   (company--posn-col-row (event-start event)))
 
@@ -2676,6 +2658,11 @@ See `company-quick-access-keys' for more details."
            (cl-position event-string company-quick-access-keys :test 'equal))))
   (when row
     (company--complete-nth row)))
+
+(defvar-local company-tooltip-offset 0
+  "Current scrolling state of the tooltip.
+Represented by the index of the first visible completion candidate
+from the candidates list.")
 
 (defun company--complete-nth (row)
   "Insert a candidate visible on the tooltip's zero-based ROW."
@@ -2930,13 +2917,6 @@ If SHOW-VERSION is non-nil, show the version in the echo area."
     (special-mode)))
 
 ;;; pseudo-tooltip ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defvar-local company-pseudo-tooltip-overlay nil)
-
-(defvar-local company-tooltip-offset 0
-  "Current scrolling state of the tooltip.
-Represented by the index of the first visible completion candidate
-from the candidates list.")
 
 (defvar-local company--tooltip-current-width 0)
 
@@ -3384,6 +3364,22 @@ Value of SELECTED determines the added face."
                 'company-tooltip-quick-access)))
 
 ;; show
+
+(defvar-local company-pseudo-tooltip-overlay nil)
+
+(defun company--inside-tooltip-p (event-col-row row height)
+  (let* ((ovl company-pseudo-tooltip-overlay)
+         (column (overlay-get ovl 'company-column))
+         (width (overlay-get ovl 'company-width))
+         (evt-col (car event-col-row))
+         (evt-row (cdr event-col-row)))
+    (and (>= evt-col column)
+         (< evt-col (+ column width))
+         (if (> height 0)
+             (and (> evt-row row)
+                  (<= evt-row (+ row height) ))
+           (and (< evt-row row)
+                (>= evt-row (+ row height)))))))
 
 (defun company--pseudo-tooltip-height ()
   "Calculate the appropriate tooltip height.


### PR DESCRIPTION
Discussed in #1143.

What if to do it this way? I tried to find an approach with the least number of changes. 

`company-pseudo-tooltip-overlay` seem to fit nicely `;; show` subsection of the `;;; pseudo-tooltip`.
`company-tooltip-offset` position is more arguable, though may be justified by the variable definition placed right before its first invocation.

Side question: are there any particular/real reason(s) for not extracting some of the functionality out of `company.el` to separate files? (f.i. starting with echo-frontends).
Based on my own perception, it might be easier to work with smaller files devoted to the specific parts of functionality. (And, potentially, that could make the code look more approachable for fixes/improvements to other programmers).

