### PR TITLE
Allow Control quick-access modifier key

### DIFF
--- a/company.el
+++ b/company.el
@@ -692,7 +692,8 @@ See `company-quick-access-keys' for more details."
   :set #'company-custom--set-quick-access
   :type '(choice (const :tag "Meta key" meta)
                  (const :tag "Super key" super)
-                 (const :tag "Hyper key" hyper))
+                 (const :tag "Hyper key" hyper)
+                 (const :tag "Control key" control))
   :package-version '(company . "0.9.14"))
 
 (defun company-keymap--quick-access-modifier ()
@@ -700,7 +701,8 @@ See `company-quick-access-keys' for more details."
   (if-let ((modifier (assoc-default company-quick-access-modifier
                                     '((meta . "M")
                                       (super . "s")
-                                      (hyper . "H")))))
+                                      (hyper . "H")
+                                      (control . "C")))))
       modifier
     (warn "company-quick-access-modifier value unknown: %S"
           company-quick-access-modifier)


### PR DESCRIPTION
Closes #1151

As was suggested, the `Control` was added to the `Customize` interface too.
The warnings given in case of an attempted default company keymap overwrite seem to be informative enough and worked smoothly during my checks.

Still, I put this key last in the list, so alternatives would be reviewed first. 