### PR TITLE
Add GitHub Actions checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    paths:
+      - '**.el'
+      - '**ci.yml'
+      - 'Makefile'
+    branches:
+      - master
+
+  pull_request:
+    paths:
+      - '**.el'
+      - '**ci.yml'
+      - 'Makefile'
+    branches:
+      - master
+
+jobs:
+  check:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs_version: [25.1, 25.3, 26.3, 27.2, snapshot]
+
+    steps:
+      - name: Setup Emacs
+        uses: purcell/setup-emacs@v3.0
+        with:
+          version: ${{ matrix.emacs_version }}
+
+      - name: Checkout Company
+        uses: actions/checkout@v2
+
+      - name: Run tests
+        run: make test-batch
+
+      - name: Run compilation
+        run: make compile-warn

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ elpa: *.el
 	tar cvf company-$$version.tar --mode 644 "$$dir"
 
 clean:
-	@rm -rf company-*/ company-*.tar company-*.tar.bz2 *.elc ert.el
+	@rm -rf company-*/ company-*.tar company-*.tar.bz2 *.elc ert.el test/*.elc
 
 test:
 	${EMACS} -Q -nw -L . -l test/all.el \
@@ -33,3 +33,8 @@ test-batch:
 
 compile:
 	${EMACS} -Q --batch -L . -f batch-byte-compile company.el company-*.el
+
+compile-warn:
+	${EMACS} -Q --batch -L . \
+	--eval "(setq byte-compile-error-on-warn t)" \
+	-f batch-byte-compile company*.el test/*.el


### PR DESCRIPTION
Hi Dmitry,
(Hope you're out from zeitnot and are doing fine.)
I've considered several possible setups - referenced below - and chose to keep it (stupid) simple:
`Makefile` already exists, is in use, and can potentially be used in future with fewer number of external dependencies.

Example with the [deliberate fails](https://github.com/yugaego/company-mode/actions/runs/1104317877).

Example with the [real checks](https://github.com/yugaego/company-mode/actions/runs/1104875213).

There's a particular issue: `company-gtags.el:79:47:Error: executable-find called with 2 arguments, but accepts only 1` on [Emacs < 27.1](https://github.com/emacs-mirror/emacs/commit/6f649e77b8512f73b17f03fd795beea9965c4029).
I didn't have a chance to put much attention to it yet: should a fallback be given for pre-27.1 Emacses? Or ignore compilation check for these versions?

If to start byte-compile `test/*.el` files, this error would appear:
`test/frontends-tests.el:153:60: Error: Unused lexical argument `candidate'`
(Same here, I didn't have a chance to look into fixing it yet).

- Would it be fine to add `test/*.el` files to `make clean` and `make compile-warn`?

## Additional Notes
### TODO
- Consider adding a linter (I've got zero knowledge at this stage about `elint`).
- Add/fix(travis) badges.

### Reference:
- [Nix usage without purcell/setup-emacs](https://github.com/magit/magit/blob/master/.github/workflows/test.yml)
- [Comparison](https://github.com/leotaku/elisp-check/blob/master/COMPARISON.md) of Emacs-related CI solutions.
- [Purcell's Linter](https://github.com/purcell/package-lint) itself and its workflow.

### Actions vs Travis

**GitHub Actions**:
- Something new to try (though might be not stable).
- Potentially could be used as one point for CI control.
- [Free usage limits](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions).
- ?Potential vendor lock-in (not a problem with a simple setup).

**Travis CI**:
- It's already setup and working.
- Not fully integrated into GitHub
  - Less visible checks results in comparison to the Actions.
- "has been trying to deprecate its open-source offering".
- ?Used to be not stable (doesn't mean it's unstable now).
