### PR TITLE
Elpaignore .github files

### DIFF
--- a/.elpaignore
+++ b/.elpaignore
@@ -1,4 +1,5 @@
 .travis.yml
+.github
 .gitignore
 Makefile
 test


### PR DESCRIPTION
It seems [ignoring `.github`](https://lists.gnu.org/archive/html/emacs-devel/2021-02/msg01230.html) files may be a good idea, they look as a redundancy on the [package download](https://elpa.gnu.org/devel/company.html).