### PR TITLE
Fix compilation warnings on Emacs 25-26

### DIFF
--- a/company-gtags.el
+++ b/company-gtags.el
@@ -67,8 +67,11 @@ completion."
   (cond
    ((not (eq company-gtags--executable 'unknown)) ;; the value is already cached
     company-gtags--executable)
-   ((and (version<= "27" emacs-version)           ;; can search remotely to set
-         (file-remote-p default-directory))
+   ((and  ;; Run remotely on supported versions of Emacs.
+     (fboundp 'with-connection-local-variables)
+     (fboundp 'connection-local-set-profile-variables)
+     (fboundp 'connection-local-set-profiles)
+     (file-remote-p default-directory))
 
     (with-connection-local-variables
      (if (boundp 'company-gtags--executable-connection)

--- a/test/core-tests.el
+++ b/test/core-tests.el
@@ -586,6 +586,10 @@
       (setq header-line-format "aaaaaaa")
       (should (= (company--row) 0)))))
 
+;; Avoid compilation warnings on Emacs 25.
+(declare-function display-line-numbers-mode "ext:display-line-numbers")
+(declare-function line-number-display-width "indent.c")
+
 (ert-deftest company-column-with-line-numbers-display ()
   :tags '(interactive)
   (skip-unless (fboundp 'display-line-numbers-mode))


### PR DESCRIPTION
Fix for #1161 .

Uses `fboundp` as suggested in the [Compiler Error docs](https://www.gnu.org/software/emacs/manual/html_node/elisp/Compiler-Errors.html).

@dgutov , I didn't test `company-gtags--executable` in action. Please do so if it's simple for you. Thank you.