### PR TITLE
Do not run CI on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   check:
+    if: github.repository_owner == 'company-mode'
     runs-on: ubuntu-20.04
 
     strategy:


### PR DESCRIPTION
I was greatly surprised to see the Company Actions running on my fork.
And I [was not alone](https://github.community/t/stop-github-actions-running-on-a-fork/17965/2).

Since the workflows minutes/storage are limited on all accounts, I suggest limit checks triggering to this repo only.