### PR TITLE
company-dabbrev/code: allow to use completion-styles for filtering

### DIFF
--- a/company-capf.el
+++ b/company-capf.el
@@ -111,27 +111,10 @@ so we can't just use the preceding variable instead.")
     (`match
      ;; Ask the for the `:company-match' function.  If that doesn't help,
      ;; fallback to sniffing for face changes to get a suitable value.
-     (let ((f (plist-get (nthcdr 4 company-capf--current-completion-data)
-                         :company-match)))
-       (if f (funcall f arg)
-         (let* ((match-start nil) (pos -1)
-                (prop-value nil)  (faces nil)
-                (has-face-p nil)  chunks
-                (limit (length arg)))
-           (while (< pos limit)
-             (setq pos
-                   (if (< pos 0) 0 (next-property-change pos arg limit)))
-             (setq prop-value (or
-                               (get-text-property pos 'face arg)
-                               (get-text-property pos 'font-lock-face arg))
-                   faces (if (listp prop-value) prop-value (list prop-value))
-                   has-face-p (memq 'completions-common-part faces))
-             (cond ((and (not match-start) has-face-p)
-                    (setq match-start pos))
-                   ((and match-start (not has-face-p))
-                    (push (cons match-start pos) chunks)
-                    (setq match-start nil))))
-           (nreverse chunks)))))
+     (let ((f (or (plist-get (nthcdr 4 company-capf--current-completion-data)
+                             :company-match)
+                  #'company--match-from-face)))
+       (funcall f arg)))
     (`duplicates t)
     (`no-cache t)   ;Not much can be done here, as long as we handle
                     ;non-prefix matches.

--- a/company-dabbrev-code.el
+++ b/company-dabbrev-code.el
@@ -81,25 +81,30 @@ also `company-dabbrev-code-time-limit'."
 The backend looks for all symbols in the current buffer that aren't in
 comments or strings."
   (interactive (list 'interactive))
-  (cl-case command
-    (interactive (company-begin-backend 'company-dabbrev-code))
-    (prefix (and (or (eq t company-dabbrev-code-modes)
-                     (apply #'derived-mode-p company-dabbrev-code-modes))
-                 (or company-dabbrev-code-everywhere
-                     (not (company-in-string-or-comment)))
-                 (or (company-grab-symbol) 'stop)))
-    (candidates (let ((case-fold-search company-dabbrev-code-ignore-case))
-                  (company-dabbrev--search
-                   (company-dabbrev-code--make-regexp arg)
-                   company-dabbrev-code-time-limit
-                   (pcase company-dabbrev-code-other-buffers
-                     (`t (list major-mode))
-                     (`code company-dabbrev-code-modes)
-                     (`all `all))
-                   (not company-dabbrev-code-everywhere))))
-    (kind 'text)
-    (ignore-case company-dabbrev-code-ignore-case)
-    (duplicates t)))
+  (pcase command
+    (`interactive (company-begin-backend 'company-dabbrev-code))
+    (`prefix (and (or (eq t company-dabbrev-code-modes)
+                      (apply #'derived-mode-p company-dabbrev-code-modes))
+                  (or company-dabbrev-code-everywhere
+                      (not (company-in-string-or-comment)))
+                  (or (company-grab-symbol) 'stop)))
+    (`candidates (let ((case-fold-search company-dabbrev-code-ignore-case))
+                   (company-dabbrev--filter
+                    arg
+                    (company-dabbrev--search
+                     (company-dabbrev-code--make-regexp
+                      (substring arg 0 company-minimum-prefix-length))
+                     company-dabbrev-code-time-limit
+                     (pcase company-dabbrev-code-other-buffers
+                       (`t (list major-mode))
+                       (`code company-dabbrev-code-modes)
+                       (`all `all))
+                     (not company-dabbrev-code-everywhere)))))
+    (`kind 'text)
+    (`ignore-case company-dabbrev-code-ignore-case)
+    (`match (company--match-from-face arg))
+    (`duplicates t)
+    (`no-cache t)))
 
 (provide 'company-dabbrev-code)
 ;;; company-dabbrev-code.el ends here

--- a/company.el
+++ b/company.el
@@ -2805,6 +2805,28 @@ from the candidates list.")
           (set-window-start nil (point)))))))
 (put 'company-show-location 'company-keep t)
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun company--match-from-face (str)
+  "Calculate `:company-match' function return via STR's face."
+  (let* ((match-start nil) (pos -1)
+         (prop-value nil)  (faces nil)
+         (has-face-p nil)  chunks
+         (limit (length str)))
+    (while (< pos limit)
+      (setq pos
+            (if (< pos 0) 0 (next-property-change pos str limit)))
+      (setq prop-value (or (get-text-property pos 'face str)
+                           (get-text-property pos 'font-lock-face str))
+            faces (if (listp prop-value) prop-value (list prop-value))
+            has-face-p (memq 'completions-common-part faces))
+      (cond ((and (not match-start) has-face-p)
+             (setq match-start pos))
+            ((and match-start (not has-face-p))
+             (push (cons match-start pos) chunks)
+             (setq match-start nil))))
+    (nreverse chunks)))
+
 ;;; package functions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defvar-local company-callback nil)


### PR DESCRIPTION
Allow to use `completion-styles` for filtering by switch to use `completion-all-completions` instead of `all-completions` for `company-dabbrev/code`.
This allows using `flex` completion style with `company-dabbrev/code`.
Also, extract the logic to calculating `:company-match` from string's faces so we can reuse it to highlight `company-dabbrev/code` items.

![image](https://user-images.githubusercontent.com/2631472/133998298-6f63d4cb-3c25-4821-b2db-de47427d9e7a.png)
