### PR TITLE
Add missing dot in `company-vscode-icons-mapping`

### DIFF
--- a/company.el
+++ b/company.el
@@ -1541,7 +1541,7 @@ end of the match."
     (string . "symbol-string.svg")
     (struct . "symbol-structure.svg")
     (text . "symbol-key.svg")
-    (type-parameter "symbol-parameter.svg")
+    (type-parameter . "symbol-parameter.svg")
     (unit . "symbol-ruler.svg")
     (value . "symbol-enumerator.svg")
     (variable . "symbol-variable.svg")


### PR DESCRIPTION
This missing dot caused `expand-file-name` to receive a list instead of a string, which in turn caused it to fail.