### PR TITLE
Rename 'auto-commit' user options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+* `company-auto-commit` and `company-auto-commit-chars` have been renamed to
+  `company-insertion-on-trigger` and `company-insertion-triggers` respectively
+  ([#1270](https://github.com/company-mode/company-mode/pull/1270)).
 * New command `company-complete-common-or-show-delayed-tooltip`
   ([#1214](https://github.com/company-mode/company-mode/discussions/1214)).
 * Faces `company-scrollbar-fg` and `company-scrollbar-bg` have been renamed to

--- a/doc/company.texi
+++ b/doc/company.texi
@@ -3,7 +3,7 @@
 @setfilename company.info
 @settitle Company User Manual
 @set VERSION 0.9.14snapshot
-@set UPDATED 28 December 2021
+@set UPDATED 8 January 2022
 @documentencoding UTF-8
 @documentlanguage en
 @paragraphindent asis
@@ -494,20 +494,11 @@ enabled @emph{company-mode} in the mode line.  The default value is
 @samp{company}.
 @end defopt
 
-@anchor{company-auto-commit}
-@defopt company-auto-commit
+@defopt company-insertion-on-trigger
 One more pair of the user options may instruct Company to complete
 with the selected candidate by typing one of the
-@code{company-auto-commit-chars} @footnote{The options
-@code{company-auto-commit} and @code{company-auto-commit-chars} used
-to be called @code{company-auto-complete} and
-@code{company-auto-complete-chars} respectively, which was in more
-accordance with the terminology given in this manual.  But the
-resulting combination of the words @samp{auto-complete} present in
-those names made it seem the role of these user options was to
-configure Company's auto-start behavior.  Hence, it was chosen to
-rename the options to, hopefully, less confusing names.}.  The user
-option @code{company-auto-commit} can be enabled or disabled by
+@code{company-insertion-triggers}.  The user option
+@code{company-insertion-on-trigger} can be enabled or disabled by
 setting its value to one of: @code{nil}, @code{t}, or a predicate
 function name.
 @ifnothtml
@@ -519,16 +510,17 @@ See @uref{https://www.gnu.org/software/emacs/manual/html_node/eintr/Wrong-Type-o
 @end ifhtml
 @end defopt
 
-@anchor{company-auto-commit-chars}
-@defopt company-auto-commit-chars
-This option acts only when @code{company-auto-commit} is enabled.  The
-value can be one of: a string of characters, a list of syntax
-description characters (@pxref{Syntax Class Table,,,elisp}), or a
-predicate function.  By default, @code{company-auto-commit-chars} is
-set to the list of the syntax characters: @w{@code{(?\ ?\) ?.)}},
-which translates to the whitespaces, close parenthesis, and
-punctuation.  The particular convenience of this user option values is
-they do not act as triggers when they are part of valid completion.
+@defopt company-insertion-triggers
+This option has an effect only when
+@w{@code{company-insertion-on-trigger}} is enabled.  The value can be
+one of: a string of characters, a list of syntax description
+characters (@pxref{Syntax Class Table,,,elisp}), or a predicate
+function.  By default, this user option is set to the list of the
+syntax characters: @w{@code{(?\ ?\) ?.)}}, which translates to the
+whitespaces, close parenthesis, and punctuation.  It is safe to
+configure the value to a character that can potentially be part of a
+valid completion; in this case, Company does not treat such characters
+as triggers.
 @end defopt
 
 @subheading Hooks

--- a/test/core-tests.el
+++ b/test/core-tests.el
@@ -273,7 +273,7 @@
     (insert "ab")
     (company-mode)
     (let (company-frontends
-          company-auto-commit
+          company-insertion-on-trigger
           (company-require-match t)
           (company-backends
            (list (lambda (command &optional _)
@@ -373,13 +373,13 @@
       (should (string= "a" (buffer-string)))
       (should (null company-candidates)))))
 
-(ert-deftest company-auto-commit-explicit ()
+(ert-deftest company-insertion-on-trigger-explicit ()
   (with-temp-buffer
     (insert "ab")
     (company-mode)
     (let (company-frontends
-          (company-auto-commit 'company-explicit-action-p)
-          (company-auto-commit-chars '(? ))
+          (company-insertion-on-trigger 'company-explicit-action-p)
+          (company-insertion-triggers '(? ))
           (company-backends
            (list (lambda (command &optional _)
                    (cl-case command
@@ -391,14 +391,14 @@
         (company-call 'self-insert-command 1))
       (should (string= "abcd " (buffer-string))))))
 
-(ert-deftest company-auto-commit-with-electric-pair ()
+(ert-deftest company-insertion-on-trigger-with-electric-pair ()
   (with-temp-buffer
     (insert "foo(ab)")
     (forward-char -1)
     (company-mode)
     (let (company-frontends
-          (company-auto-commit t)
-          (company-auto-commit-chars '(? ?\)))
+          (company-insertion-on-trigger t)
+          (company-insertion-triggers '(? ?\)))
           (company-backends
            (list (lambda (command &optional _)
                    (cl-case command
@@ -416,13 +416,13 @@
           (electric-pair-mode -1)))
       (should (string= "foo(abcd)" (buffer-string))))))
 
-(ert-deftest company-no-auto-commit-when-idle ()
+(ert-deftest company-no-insertion-on-trigger-when-idle ()
   (with-temp-buffer
     (insert "ab")
     (company-mode)
     (let (company-frontends
-          (company-auto-commit 'company-explicit-action-p)
-          (company-auto-commit-chars '(? ))
+          (company-insertion-on-trigger 'company-explicit-action-p)
+          (company-insertion-triggers '(? ))
           (company-minimum-prefix-length 2)
           (company-backends
            (list (lambda (command &optional _)


### PR DESCRIPTION
Based on #1264.

I'm still considering if this would be a good idea to apply this change.
It may be convenient considering it in parallel with the suggested manual text. 
So let's keep it open for now, without merging.

My first serious attempt was to use `company-triggered-complete`/`company-triggered-complete-chars` but that proved to be a weak choice on a closer look (as with many other names).

The current choice seems to be self-explanatory (as of today) but its long-ish.