### PR TITLE
Rename tooltip scrollbar faces

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+* Faces `company-scrollbar-fg` and `company-scrollbar-bg` have been renamed to
+  `company-tooltip-scrollbar-thumb` and `company-tooltip-scrollbar-track`
+  respectively.
 * Better compatibility with `visual-line-mdoe`
   ([#1257](https://github.com/company-mode/company-mode/issues/1257)).
 * Better compatibility with `org-indent-mode`

--- a/company.el
+++ b/company.el
@@ -140,19 +140,29 @@
   "Face used for the selected quick-access hints shown in the tooltip."
   :package-version '(company . "0.9.14"))
 
-(defface company-scrollbar-fg
+(define-obsolete-face-alias
+ 'company-scrollbar-fg
+ 'company-tooltip-scrollbar-thumb
+ "0.9.14")
+
+(defface company-tooltip-scrollbar-thumb
   '((((background light))
      :background "darkred")
     (((background dark))
      :background "gray33"))
-  "Face used for the tooltip scrollbar thumb.")
+  "Face used for the tooltip scrollbar thumb (bar).")
 
-(defface company-scrollbar-bg
+(define-obsolete-face-alias
+ 'company-scrollbar-bg
+ 'company-tooltip-scrollbar-track
+ "0.9.14")
+
+(defface company-tooltip-scrollbar-track
   '((((background light))
      :background "wheat")
     (((background dark))
      :background "gray28"))
-  "Face used for the tooltip scrollbar background.")
+  "Face used for the tooltip scrollbar track (trough).")
 
 (defface company-preview
   '((default :inherit (company-tooltip-selection company-tooltip)))
@@ -3383,8 +3393,8 @@ but adjust the expected values appropriately."
 (defun company--scrollbar (i bounds)
   (propertize " " 'face
               (if (and (>= i (car bounds)) (<= i (cdr bounds)))
-                  'company-scrollbar-fg
-                'company-scrollbar-bg)))
+                  'company-tooltip-scrollbar-thumb
+                'company-tooltip-scrollbar-track)))
 
 (defun company--scrollpos-line (text width fancy-margin-width)
   (propertize (concat (company-space-string company-tooltip-margin)


### PR DESCRIPTION
This PR suggests using more descriptive faces names, better fitting the rest of the `tooltip` related faces.

Also, the `-fg`/`-bg` part may make it look like `:foreground`/`:background` face attribute is (only) set there.
