### PR TITLE
Fix company-files-exclusions docstring and application

### DIFF
--- a/company-files.el
+++ b/company-files.el
@@ -33,9 +33,9 @@
   :group 'company)
 
 (defcustom company-files-exclusions nil
-  "File name extensions and directory names to ignore.
+  "A list of file name extensions and directory names to ignore.
 The values should use the same format as `completion-ignored-extensions'."
-  :type '(const string)
+  :type '(repeat (string :tag "File extension or directory name"))
   :package-version '(company . "0.9.1"))
 
 (defcustom company-files-chop-trailing-slash t
@@ -59,7 +59,7 @@ Set this to nil to disable that behavior."
     (file-error nil)))
 
 (defun company-files--exclusions-filtered (completions)
-  (let* ((dir-exclusions (cl-delete-if-not #'company-files--trailing-slash-p
+  (let* ((dir-exclusions (cl-remove-if-not #'company-files--trailing-slash-p
                                            company-files-exclusions))
          (file-exclusions (cl-set-difference company-files-exclusions
                                              dir-exclusions)))

--- a/test/files-tests.el
+++ b/test/files-tests.el
@@ -46,3 +46,12 @@
     (should-not (member (expand-file-name "company.el" company-dir)
                         (company-files 'candidates
                                        company-dir)))))
+
+(ert-deftest company-files-candidates-excluding-dir-and-files ()
+  (let* ((company-files-exclusions '("test/" ".el"))
+         company-files--completion-cache
+         (files-candidates (company-files 'candidates company-dir)))
+    (should-not (member (expand-file-name "test/" company-dir)
+                        files-candidates))
+    (should-not (member (expand-file-name "company.el" company-dir)
+                        files-candidates))))


### PR DESCRIPTION
Replaces destructive `cl-delete-if-not` by non-destructive `cl-remove-if-not` to still exclude files when a directory is also configured for exclusion. The added test demonstrates the fixed case. (I checked it on Emacs 28.0.90).

Also improves the docstring and `:type` of this option. 