### PR TITLE
Bind ‘non-essential’ when performing idle completion.

### DIFF
--- a/company.el
+++ b/company.el
@@ -1898,9 +1898,10 @@ prefix match (same case) will be prioritized."
        (eq win (selected-window))
        (eq tick (buffer-chars-modified-tick))
        (eq pos (point))
-       (when (company-auto-begin)
-         (let ((this-command 'company-idle-begin))
-           (company-post-command)))))
+       (let ((non-essential t))
+         (when (company-auto-begin)
+           (let ((this-command 'company-idle-begin))
+             (company-post-command))))))
 
 (defun company-auto-begin ()
   (and company-mode


### PR DESCRIPTION
Idle completion isn’t a direct response to a user action, so I believe marking
it as non-essential is justified.