### PR TITLE
company-complete: Insert current selection when no more common part

### DIFF
--- a/company.el
+++ b/company.el
@@ -2645,7 +2645,9 @@ inserted."
   (when (company-manual-begin)
     (if (or company-selection-changed
             (and (eq real-last-command 'company-complete)
-                 (eq last-command 'company-complete-common)))
+                 (eq last-command 'company-complete-common))
+            (not company-common)
+            (equal company-prefix company-common))
         (call-interactively 'company-complete-selection)
       (call-interactively 'company-complete-common)
       (when company-candidates


### PR DESCRIPTION
When bind `company-complete`  to the completion key ( usually `<tab>`), If candidates have no more common part and the first candidate is just in need, press `<tab>` once to insert current selection, rather than  press `<tab>` twice that really make annoyed. Or in this situation I should use `<enter>` to insert it ,  in other case use `<tab> `? 



