### PR TITLE
Update copyright information

### DIFF
--- a/company-abbrev.el
+++ b/company-abbrev.el
@@ -1,6 +1,6 @@
 ;;; company-abbrev.el --- company-mode completion backend for abbrev
 
-;; Copyright (C) 2009-2011, 2015, 2021  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2011, 2013-2015, 2021  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 

--- a/company-bbdb.el
+++ b/company-bbdb.el
@@ -1,6 +1,6 @@
 ;;; company-bbdb.el --- company-mode completion backend for BBDB in message-mode
 
-;; Copyright (C) 2013-2014, 2016  Free Software Foundation, Inc.
+;; Copyright (C) 2013-2016, 2020  Free Software Foundation, Inc.
 
 ;; Author: Jan Tatarik <jan.tatarik@gmail.com>
 

--- a/company-capf.el
+++ b/company-capf.el
@@ -1,6 +1,6 @@
 ;;; company-capf.el --- company-mode completion-at-point-functions backend -*- lexical-binding: t -*-
 
-;; Copyright (C) 2013-2019, 2021  Free Software Foundation, Inc.
+;; Copyright (C) 2013-2021  Free Software Foundation, Inc.
 
 ;; Author: Stefan Monnier <monnier@iro.umontreal.ca>
 

--- a/company-clang.el
+++ b/company-clang.el
@@ -1,6 +1,6 @@
 ;;; company-clang.el --- company-mode completion backend for Clang  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2009, 2011, 2013-2019  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2011, 2013-2021  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 

--- a/company-cmake.el
+++ b/company-cmake.el
@@ -1,6 +1,6 @@
 ;;; company-cmake.el --- company-mode completion backend for CMake
 
-;; Copyright (C) 2013-2014, 2017-2018  Free Software Foundation, Inc.
+;; Copyright (C) 2013-2015, 2017-2018, 2020  Free Software Foundation, Inc.
 
 ;; Author: Chen Bin <chenbin DOT sh AT gmail>
 ;; Version: 0.2

--- a/company-css.el
+++ b/company-css.el
@@ -1,6 +1,6 @@
 ;;; company-css.el --- company-mode completion backend for css-mode  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2009, 2011, 2014, 2018  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2011, 2013-2015, 2018  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 

--- a/company-dabbrev-code.el
+++ b/company-dabbrev-code.el
@@ -1,6 +1,6 @@
 ;;; company-dabbrev-code.el --- dabbrev-like company-mode backend for code  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2009, 2011, 2014  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2011, 2013-2016, 2021  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 

--- a/company-dabbrev.el
+++ b/company-dabbrev.el
@@ -1,6 +1,6 @@
 ;;; company-dabbrev.el --- dabbrev-like company-mode completion backend  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2009, 2011, 2014, 2015, 2016  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2011, 2013-2018, 2021  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 

--- a/company-elisp.el
+++ b/company-elisp.el
@@ -1,6 +1,6 @@
 ;;; company-elisp.el --- company-mode completion backend for Emacs Lisp -*- lexical-binding: t -*-
 
-;; Copyright (C) 2009, 2011-2013, 2017  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2015, 2017, 2020  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 

--- a/company-etags.el
+++ b/company-etags.el
@@ -1,6 +1,6 @@
 ;;; company-etags.el --- company-mode completion backend for etags
 
-;; Copyright (C) 2009-2011, 2014  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2011, 2013-2015, 2018-2019  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 

--- a/company-files.el
+++ b/company-files.el
@@ -1,6 +1,6 @@
 ;;; company-files.el --- company-mode completion backend for file names
 
-;; Copyright (C) 2009-2011, 2014-2021  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2011, 2013-2021  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 

--- a/company-gtags.el
+++ b/company-gtags.el
@@ -1,6 +1,6 @@
 ;;; company-gtags.el --- company-mode completion backend for GNU Global
 
-;; Copyright (C) 2009-2011, 2014-2020  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2011, 2013-2021  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 

--- a/company-ispell.el
+++ b/company-ispell.el
@@ -1,6 +1,6 @@
 ;;; company-ispell.el --- company-mode completion backend using Ispell
 
-;; Copyright (C) 2009-2011, 2013-2016  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2011, 2013-2016, 2018, 2021  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 

--- a/company-keywords.el
+++ b/company-keywords.el
@@ -1,6 +1,6 @@
 ;;; company-keywords.el --- A company backend for programming language keywords
 
-;; Copyright (C) 2009-2011, 2016  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2011, 2013-2018, 2020-2021  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 

--- a/company-nxml.el
+++ b/company-nxml.el
@@ -1,6 +1,6 @@
 ;;; company-nxml.el --- company-mode completion backend for nxml-mode
 
-;; Copyright (C) 2009-2011, 2013, 2018  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2011, 2013-2015, 2017-2018  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 

--- a/company-oddmuse.el
+++ b/company-oddmuse.el
@@ -1,6 +1,6 @@
 ;;; company-oddmuse.el --- company-mode completion backend for oddmuse-mode
 
-;; Copyright (C) 2009-2011, 2014  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2011, 2013-2016  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 

--- a/company-semantic.el
+++ b/company-semantic.el
@@ -1,6 +1,6 @@
 ;;; company-semantic.el --- company-mode completion backend using Semantic
 
-;; Copyright (C) 2009-2011, 2013-2016  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2011, 2013-2018  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 

--- a/company-template.el
+++ b/company-template.el
@@ -1,6 +1,6 @@
 ;;; company-template.el --- utility library for template expansion
 
-;; Copyright (C) 2009, 2010, 2014-2017 Free Software Foundation, Inc.
+;; Copyright (C) 2009-2010, 2013-2017, 2019  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 

--- a/company-tempo.el
+++ b/company-tempo.el
@@ -1,6 +1,6 @@
 ;;; company-tempo.el --- company-mode completion backend for tempo
 
-;; Copyright (C) 2009-2011, 2015  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2011, 2013-2016  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 

--- a/company-yasnippet.el
+++ b/company-yasnippet.el
@@ -1,6 +1,6 @@
 ;;; company-yasnippet.el --- company-mode completion backend for Yasnippet
 
-;; Copyright (C) 2014, 2015, 2020  Free Software Foundation, Inc.
+;; Copyright (C) 2014-2015, 2020-2021  Free Software Foundation, Inc.
 
 ;; Author: Dmitry Gutov
 

--- a/company.el
+++ b/company.el
@@ -1,6 +1,6 @@
 ;;; company.el --- Modular text completion framework  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2009-2021  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2022  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 ;; Maintainer: Dmitry Gutov <dgutov@yandex.ru>

--- a/doc/company.texi
+++ b/doc/company.texi
@@ -13,7 +13,7 @@
 This user manual is for Company version @value{VERSION}
 @w{(@value{UPDATED})}.
 
-Copyright @copyright{} 2021 Free Software Foundation, Inc.
+Copyright @copyright{} 2021-2022  Free Software Foundation, Inc.
 
 @quotation
 Permission is granted to copy, distribute and/or modify this document

--- a/doc/images/large/README
+++ b/doc/images/large/README
@@ -1,0 +1,6 @@
+This directory contains images for the HTML version of the User Manual.
+
+COPYRIGHT AND LICENSE INFORMATION FOR IMAGE FILES
+
+Copyright (C) 2021 Free Software Foundation, Inc.
+License: GNU General Public License version 3 or later (see LICENSE)

--- a/doc/images/small/README
+++ b/doc/images/small/README
@@ -1,0 +1,6 @@
+This directory contains images for the Info version of the User Manual.
+
+COPYRIGHT AND LICENSE INFORMATION FOR IMAGE FILES
+
+Copyright (C) 2021 Free Software Foundation, Inc.
+License: GNU General Public License version 3 or later (see LICENSE)

--- a/test/all.el
+++ b/test/all.el
@@ -1,6 +1,6 @@
 ;;; all-tests.el --- company-mode tests  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015  Free Software Foundation, Inc.
+;; Copyright (C) 2015, 2018  Free Software Foundation, Inc.
 
 ;; Author: Dmitry Gutov
 

--- a/test/async-tests.el
+++ b/test/async-tests.el
@@ -1,6 +1,6 @@
 ;;; async-tests.el --- company-mode tests  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015, 2016, 2018, 2020-2021  Free Software Foundation, Inc.
+;; Copyright (C) 2015-2016, 2018, 2020-2021  Free Software Foundation, Inc.
 
 ;; Author: Dmitry Gutov
 

--- a/test/capf-tests.el
+++ b/test/capf-tests.el
@@ -1,9 +1,9 @@
 ;;; capf-tests.el --- company tests for the company-capf backend  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2018  Free Software Foundation, Inc.
+;; Copyright (C) 2018-2019, 2021  Free Software Foundation, Inc.
 
 ;; Author: João Távora <joaotavora@gmail.com>
-;; Keywords: 
+;; Keywords:
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -19,8 +19,6 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-
-;; 
 
 ;;; Code:
 

--- a/test/clang-tests.el
+++ b/test/clang-tests.el
@@ -1,6 +1,6 @@
 ;;; clang-tests.el --- company-mode tests  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015  Free Software Foundation, Inc.
+;; Copyright (C) 2015, 2017  Free Software Foundation, Inc.
 
 ;; Author: Dmitry Gutov
 

--- a/test/cmake-tests.el
+++ b/test/cmake-tests.el
@@ -1,6 +1,6 @@
 ;;; cmake-tests.el --- company-mode tests  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2017  Free Software Foundation, Inc.
+;; Copyright (C) 2017, 2018  Free Software Foundation, Inc.
 
 ;; Author: Zuogong Yue
 

--- a/test/core-tests.el
+++ b/test/core-tests.el
@@ -1,6 +1,6 @@
 ;;; core-tests.el --- company-mode tests  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015, 2016, 2017  Free Software Foundation, Inc.
+;; Copyright (C) 2015-2018, 2020-2021  Free Software Foundation, Inc.
 
 ;; Author: Dmitry Gutov
 

--- a/test/files-tests.el
+++ b/test/files-tests.el
@@ -1,6 +1,6 @@
 ;;; filtes-tests.el --- company-mode tests  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2016  Free Software Foundation, Inc.
+;; Copyright (C) 2016, 2021  Free Software Foundation, Inc.
 
 ;; Author: Dmitry Gutov
 

--- a/test/frontends-tests.el
+++ b/test/frontends-tests.el
@@ -1,6 +1,6 @@
 ;;; frontends-tests.el --- company-mode tests  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015, 2016  Free Software Foundation, Inc.
+;; Copyright (C) 2015-2017, 2020-2021  Free Software Foundation, Inc.
 
 ;; Author: Dmitry Gutov
 

--- a/test/template-tests.el
+++ b/test/template-tests.el
@@ -1,6 +1,6 @@
 ;;; template-tests.el --- company-mode tests  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015  Free Software Foundation, Inc.
+;; Copyright (C) 2015-2017  Free Software Foundation, Inc.
 
 ;; Author: Dmitry Gutov
 


### PR DESCRIPTION
I inferred the copyright year should be added only to the files updated during that year (approx. > 15 lines change).
Is it correct?

This patch adds copyright information to the makefiles and /doc/images according to the approach
suggested in the `<emacs-source>/admin/notes/copyright` file:
- Add copyright to the files larger than 15 lines.
- Add README file to each folder with the images.
