### PR TITLE
company-yasnippet: avoid choose value prompts when fetching snippet doc

### DIFF
--- a/company-yasnippet.el
+++ b/company-yasnippet.el
@@ -119,6 +119,7 @@ It has to accept one argument: the snippet's name.")
     (with-current-buffer (company-doc-buffer)
       (let ((buffer-file-name file-name))
         (yas-minor-mode 1)
+        (set (make-local-variable 'yas-prompt-functions) '(yas-no-prompt))
         (condition-case error
             (yas-expand-snippet (yas--template-content template))
           (error


### PR DESCRIPTION
Avoid choose value prompts when fetching snippet documentation by setting local buffer variable `yas-prompt-functions` to `'(yas-no-prompt)`. This is needed when a snippet field has multiple values to choose.