### PR TITLE
CI: Run tests on latest releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,12 @@ on:
 jobs:
   check:
     if: github.repository_owner == 'company-mode'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        emacs_version: [25.1, 25.3, 26.3, 27.2, snapshot]
+        emacs_version: [25.1, 25.3, 26.3, 27.2, 28.1, snapshot]
 
     steps:
       - name: Setup Emacs


### PR DESCRIPTION
Add `Emacs 28.1` and switch to `ubuntu-latest` (still 20.04 now; 22.04 environment is in beta).