### PR TITLE
Pacify Emacs 29 compiler warnings

### DIFF
--- a/company-oddmuse.el
+++ b/company-oddmuse.el
@@ -1,6 +1,6 @@
 ;;; company-oddmuse.el --- company-mode completion backend for oddmuse-mode
 
-;; Copyright (C) 2009-2011, 2013-2016  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2011, 2013-2016, 2022  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 
@@ -48,7 +48,7 @@
     (interactive (company-begin-backend 'company-oddmuse))
     (prefix (let ((case-fold-search nil))
               (and (memq major-mode '(oddmuse-mode yaoddmuse-mode))
-                   (looking-back company-oddmuse-link-regexp (point-at-bol))
+                   (looking-back company-oddmuse-link-regexp (line-beginning-position))
                    (or (match-string 1)
                        (match-string 2)))))
     (candidates (all-completions arg (company-oddmuse-get-page-table)))))

--- a/company.el
+++ b/company.el
@@ -1075,7 +1075,7 @@ If EXPRESSION is non-nil, return the match string for the respective
 parenthesized expression in REGEXP.
 Matching is limited to the current line."
   (let ((inhibit-field-text-motion t))
-    (company-grab regexp expression (point-at-bol))))
+    (company-grab regexp expression (line-beginning-position))))
 
 (defun company-grab-symbol ()
   "If point is at the end of a symbol, return it.


### PR DESCRIPTION
* company-oddmuse.el (company-oddmuse):
* company.el (company-grab-line): Use `line-beginning-position'
instead of `point-at-bol' which is made obsolete with Emacs 29.