### PR TITLE
Pacify Emacs 29 compiler warning

### DIFF
--- a/company.el
+++ b/company.el
@@ -1795,7 +1795,7 @@ PROPERTY return nil."
   (if (and (display-graphic-p)
            (image-type-available-p 'svg))
       (cl-case (frame-parameter nil 'background-mode)
-        ('light (company-vscode-light-icons-margin candidate selected))
+        (light (company-vscode-light-icons-margin candidate selected))
         (t (company-vscode-dark-icons-margin candidate selected)))
     (company-text-icons-margin candidate selected)))
 


### PR DESCRIPTION
* company.el (company-detect-icons-margin): Unquote the light key and silence the compiler warning "Case 'light will match `quote'".