### PR TITLE
Silence warnings about unused lexical argument `ignored'

### DIFF
--- a/company-clang.el
+++ b/company-clang.el
@@ -357,7 +357,7 @@ or automatically through a custom `company-clang-prefix-guesser'."
          (string-to-number (match-string-no-properties 2)))
       0)))
 
-(defun company-clang (command &optional arg &rest ignored)
+(defun company-clang (command &optional arg &rest _ignored)
   "`company-mode' completion backend for Clang.
 Clang is a parser for C and ObjC.  Clang version 1.1 or newer is required.
 

--- a/company-dabbrev-code.el
+++ b/company-dabbrev-code.el
@@ -76,7 +76,7 @@ also `company-dabbrev-code-time-limit'."
           "\\(\\sw\\|\\s_\\)*\\_>"))
 
 ;;;###autoload
-(defun company-dabbrev-code (command &optional arg &rest ignored)
+(defun company-dabbrev-code (command &optional arg &rest _ignored)
   "dabbrev-like `company-mode' backend for code.
 The backend looks for all symbols in the current buffer that aren't in
 comments or strings."

--- a/company-dabbrev.el
+++ b/company-dabbrev.el
@@ -179,7 +179,7 @@ This variable affects both `company-dabbrev' and `company-dabbrev-code'."
     (all-completions prefix candidates)))
 
 ;;;###autoload
-(defun company-dabbrev (command &optional arg &rest ignored)
+(defun company-dabbrev (command &optional arg &rest _ignored)
   "dabbrev-like `company-mode' completion backend."
   (interactive (list 'interactive))
   (cl-case command

--- a/company.el
+++ b/company.el
@@ -2887,7 +2887,7 @@ automatically show the documentation buffer for each selection."
 
 (defvar-local company-callback nil)
 
-(defun company-remove-callback (&optional ignored)
+(defun company-remove-callback (&optional _ignored)
   (remove-hook 'company-completion-finished-hook company-callback t)
   (remove-hook 'company-completion-cancelled-hook 'company-remove-callback t)
   (remove-hook 'company-completion-finished-hook 'company-remove-callback t))
@@ -2921,7 +2921,7 @@ successfully completes the input.
 Example: \(company-begin-with \\='\(\"foo\" \"foobar\" \"foobarbaz\"\)\)"
   (let ((begin-marker (copy-marker (point) t)))
     (company-begin-backend
-     (lambda (command &optional arg &rest ignored)
+     (lambda (command &optional arg &rest _ignored)
        (pcase command
          (`prefix
           (when (equal (point) (marker-position begin-marker))


### PR DESCRIPTION
* company-clang.el (company-clang):
* company-dabbrev-code.el (company-dabbrev-code):
* company-dabbrev.el (company-dabbrev):
* company.el (company-remove-callback, company-begin-with): Prefix ignored argument with '_'.