### PR TITLE
Bits of Maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,22 +19,21 @@ on:
 
 jobs:
   check:
-    if: github.repository_owner == 'company-mode'
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        emacs_version: [25.1, 25.3, 26.3, 27.2, 28.1, snapshot]
+        emacs_version: [25.1, 25.3, 26.3, 27.2, 28.2, snapshot]
 
     steps:
       - name: Setup Emacs
-        uses: purcell/setup-emacs@v3.0
+        uses: purcell/setup-emacs@master
         with:
           version: ${{ matrix.emacs_version }}
 
       - name: Checkout Company
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run tests
         run: make test-batch

--- a/doc/company.texi
+++ b/doc/company.texi
@@ -31,6 +31,7 @@ any later version published by the Free Software Foundation.
 @title Company User Manual
 @subtitle for version @value{VERSION}
 @subtitle @value{UPDATED}
+@author YugaEgo (@email{yet@@ego.team})
 @page
 @vskip 0pt plus 1filll
 @insertcopying


### PR DESCRIPTION
CI filter by repository is not needed since Actions are disabled by default on forks. 

Use the latest libs to prevent [GitHub Actions warnings](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).
