### PR TITLE
company--posn-col-row: fix wrong col value with RTL direction

### DIFF
--- a/company.el
+++ b/company.el
@@ -1061,6 +1061,10 @@ means that `company-mode' is always turned on except in `message-mode' buffers."
         (row (cdr (or (posn-actual-col-row posn)
                       ;; When position is non-visible for some reason.
                       (posn-col-row posn)))))
+    ;; posn-col-row return value relative to the left
+    (when (eq (current-bidi-paragraph-direction) 'right-to-left)
+      (let ((ww (window-body-width)))
+        (setq col (- ww col))))
     (when (bound-and-true-p display-line-numbers)
       (cl-decf col (+ 2 (line-number-display-width))))
     (cons (+ col (window-hscroll)) row)))

--- a/test/frontends-tests.el
+++ b/test/frontends-tests.el
@@ -59,6 +59,22 @@
         (should (string= (overlay-get ov 'company-display)
                          "  123 \nc 45  c\nddd\n")))))))
 
+(ert-deftest company-pseudo-tooltip-show-at-point-RTL ()
+  :tags '(interactive)
+  (with-temp-buffer
+    (save-window-excursion
+    (set-window-buffer nil (current-buffer))
+    (setq bidi-display-reordering t)
+    (setq bidi-paragraph-direction 'right-to-left)
+    (insert "انا مثال للكتابة بالعربية")
+    (search-backward "مثال")
+    (let ((company-candidates-length 2)
+          (company-candidates '("123" "45"))
+          (company-backend 'ignore))
+      (company-pseudo-tooltip-show-at-point (point) 0)
+      (let ((ov company-pseudo-tooltip-overlay))
+        (should (eq (overlay-get ov 'company-column) 5)))))))
+
 (ert-deftest company-pseudo-tooltip-edit-updates-width ()
   :tags '(interactive)
   (with-temp-buffer


### PR DESCRIPTION
`posn-col-row` return value relative to the left, which make the overlay appears in completely wrong position when using a RTL language and `bidi-paragraph-direction` set no nil or forcing right-to-left.

To reproduce set bidi-paragraph-direction to right-to-left.