### PR TITLE
Fix byte-compiler warning

### DIFF
--- a/test/frontends-tests.el
+++ b/test/frontends-tests.el
@@ -486,7 +486,7 @@
              "-*-foobar zz"))))
 
 (ert-deftest company-modify-line-with-invisible-prop ()
-  (let ((str "-*-foobar")
+  (let ((str (copy-sequence "-*-foobar"))
         (buffer-invisibility-spec '((outline . t) t)))
     (put-text-property 1 2 'invisible 'foo str)
     (should (equal


### PR DESCRIPTION
Adds `copy-sequence`, as was suggested in https://github.com/company-mode/company-mode/pull/1387#issuecomment-1615997805