### PR TITLE
CI: run tests on Emacs 29.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        emacs_version: [25.1, 25.3, 26.3, 27.2, 28.2, snapshot]
+        emacs_version: [25.1, 25.3, 26.3, 27.2, 28.2, 29.1, snapshot]
 
     steps:
       - name: Setup Emacs


### PR DESCRIPTION
The latest release is added to run tests for it.