### PR TITLE
Add explicit caching mechanism (for backends) and fold the `keep-prefix` logic inside

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 # Next
 
+* The backend command `keep-prefix` is being phased out.  The built-in backends
+  implement it internally now, which resolved a number of sharp edges (mostly)
+  around "grouped" backends.  To make that easier, several helpers were added,
+  such as `company-cache-fetch` and `company-substitute-prefix`
+  ([#1411](https://github.com/company-mode/company-mode/pull/1411)).  And
+  `company-ispell` uses the cache to keep the currently selected dictionary
+  loaded in memory between completions.
 * The "length override" behavior in grouped backends now acts on each backend
   separately ([#1405](https://github.com/company-mode/company-mode/pull/1405)).
 

--- a/company-dabbrev.el
+++ b/company-dabbrev.el
@@ -70,10 +70,7 @@ candidate is inserted, even some of its characters have different case."
 
 The value of nil means keep them as-is.
 `case-replace' means use the value of `case-replace'.
-Any other value means downcase.
-
-If you set this value to nil, you may also want to set
-`company-dabbrev-ignore-case' to any value other than `keep-prefix'."
+Any other value means downcase."
   :type '(choice
           (const :tag "Keep as-is" nil)
           (const :tag "Downcase" t)
@@ -177,8 +174,13 @@ This variable affects both `company-dabbrev' and `company-dabbrev-code'."
                        1)))
 
 (defun company-dabbrev--filter (prefix candidates)
-  (let ((completion-ignore-case company-dabbrev-ignore-case))
-    (all-completions prefix candidates)))
+  (let* ((completion-ignore-case company-dabbrev-ignore-case)
+         (filtered (all-completions prefix candidates))
+         (lp (length prefix)))
+    (if (and (eq company-dabbrev-ignore-case 'keep-prefix)
+             (not (= lp 0)))
+        (company-substitute-prefix prefix filtered)
+      filtered)))
 
 (defun company-dabbrev--fetch ()
   (let ((words (company-dabbrev--search (company-dabbrev--make-regexp)
@@ -207,7 +209,7 @@ This variable affects both `company-dabbrev' and `company-dabbrev-code'."
                            :expire t)))
     (kind 'text)
     (no-cache t)
-    (ignore-case company-dabbrev-ignore-case)
+    (ignore-case (and company-dabbrev-ignore-case t))
     (duplicates t)))
 
 (provide 'company-dabbrev)

--- a/company-ispell.el
+++ b/company-ispell.el
@@ -80,12 +80,14 @@ If nil, use `ispell-complete-word-dict'."
        (if (string= arg "")
            ;; Small optimization.
            all-words
-         ;; Work around issue #284.
-         (all-completions arg all-words))))
+         (company-substitute-prefix
+          arg
+          ;; Work around issue #284.
+          (all-completions arg all-words)))))
     (kind 'text)
     (no-cache t)
     (sorted t)
-    (ignore-case 'keep-prefix)))
+    (ignore-case t)))
 
 (provide 'company-ispell)
 ;;; company-ispell.el ends here

--- a/company.el
+++ b/company.el
@@ -1133,6 +1133,15 @@ matches IDLE-BEGIN-AFTER-RE, return it wrapped in a cons."
         (car (setq ppss (cdr ppss)))
         (nth 3 ppss))))
 
+(defun company-substitute-prefix (prefix strings)
+  (let ((len (length prefix)))
+    (mapcar
+     (lambda (s)
+       (if (eq t (compare-strings prefix 0 len s 0 len))
+           s
+         (concat prefix (substring s len))))
+     strings)))
+
 (defvar company--cache (make-hash-table :test #'equal :size 10))
 
 (cl-defun company-cache-fetch (key


### PR DESCRIPTION
Implement `keep-prefix` inside the backends that advertise this capability (dabbrev and ispell), using the cache helpers, with the intention to drop support for this backend action at some later date.
 
Previously described in https://github.com/company-mode/company-mode/issues/285#issuecomment-105237695.

Resolves #285.

Fixes #413, fixes #1072, fixes #1096, resolves #1063, addresses #1226.

The more ambitious full case conversion (upcase/downcase/snake/camel, mentioned in https://github.com/company-mode/company-mode/issues/1096#issuecomment-824949311), is out of scope for this particular change, but could be added later by either altering the new helper, or adding another one. I'm concerned about the performance for certain backends (such as ispell), so maybe the latter.