### PR TITLE
company-dabbrev: Fix mismatched type in company-dabbrev--fetch

### DIFF
--- a/company-dabbrev.el
+++ b/company-dabbrev.el
@@ -183,11 +183,12 @@ This variable affects both `company-dabbrev' and `company-dabbrev-code'."
       filtered)))
 
 (defun company-dabbrev--fetch ()
-  (let ((words (company-dabbrev--search (company-dabbrev--make-regexp)
-                                        company-dabbrev-time-limit
-                                        (pcase company-dabbrev-other-buffers
-                                          (`t (list major-mode))
-                                          (`all `all))))
+  (let ((words (hash-table-keys
+                (company-dabbrev--search (company-dabbrev--make-regexp)
+                                         company-dabbrev-time-limit
+                                         (pcase company-dabbrev-other-buffers
+                                           (`t (list major-mode))
+                                           (`all `all)))))
         (downcase-p (if (eq company-dabbrev-downcase 'case-replace)
                         case-replace
                       company-dabbrev-downcase)))


### PR DESCRIPTION
This fixes a regression introduced in 374322cea.

Before that commit, `company-dabbrev--fetch` calls `company-dabbrev--search` which returns a hash table. Then `company-dabbrev--filter` converts it to a list (hash table's keys), then `(mapcar 'downcase words)` is applied to the list.

After that commit, if `downcase-p` is set then the hash table is passed directly to `(mapcar 'downcase words)` which produces an error `Wrong type argument: sequencep, #s(hash-table ...`

This commit changes the return type of `company-dabbrev--fetch` from a hash table to a list, although that doesn't seem to break other functionality in quick testing.

Thanks for all your work on company-mode, it's incredibly handy! :grin: 