### PR TITLE
Add the 'smart ignore-case' behavior

### DIFF
--- a/company-dabbrev-code.el
+++ b/company-dabbrev-code.el
@@ -107,7 +107,8 @@ comments or strings."
                      (not (company-in-string-or-comment)))
                  (or (company-grab-symbol) 'stop)))
     (candidates
-     (let* ((case-fold-search company-dabbrev-code-ignore-case)
+     (let* ((case-fold-search (and company-dabbrev-code-ignore-case
+                                   (company-smart-ignore-case arg)))
             (regexp (company-dabbrev-code--make-regexp arg)))
        (company-dabbrev-code--filter
         arg
@@ -126,7 +127,8 @@ comments or strings."
          :check-tag regexp))))
     (kind 'text)
     (no-cache t)
-    (ignore-case company-dabbrev-code-ignore-case)
+    (ignore-case (and company-dabbrev-code-ignore-case
+                      (company-smart-ignore-case arg)))
     (match (when company-dabbrev-code-completion-styles
              (company--match-from-capf-face arg)))
     (duplicates t)))


### PR DESCRIPTION
If the prefix has uppercase chars, then match case-sensitively, otherwise insensitively.

This seems easy enough to do when the choice is still on the backend level.

TODO: Update user options and other backends.