### PR TITLE
Add php-ts-mode as an alias of php-mode

### DIFF
--- a/company-keywords.el
+++ b/company-keywords.el
@@ -427,6 +427,7 @@
     (cperl-mode . perl-mode)
     (jde-mode . java-mode)
     (ess-julia-mode . julia-mode)
+    (php-ts-mode . php-mode)
     (phps-mode . php-mode)
     (enh-ruby-mode . ruby-mode))
   "Alist mapping major-modes to sorted keywords for `company-keywords'.")


### PR DESCRIPTION
Add support for [php-ts-mode](https://github.com/emacs-php/php-ts-mode). This package is not yet available in any ELPA, but will be submitted to GNU ELPA in due course.

refs https://github.com/emacs-php/php-ts-mode/issues/55