### PR TITLE
treewide: replace `looking-at` with `looking-at-p` if match data unused

### DIFF
--- a/company-dabbrev.el
+++ b/company-dabbrev.el
@@ -167,7 +167,7 @@ This variable affects both `company-dabbrev' and `company-dabbrev-code'."
 
 (defun company-dabbrev--prefix ()
   ;; Not in the middle of a word.
-  (unless (looking-at company-dabbrev-char-regexp)
+  (unless (looking-at-p company-dabbrev-char-regexp)
     ;; Emacs can't do greedy backward-search.
     (company-grab-line (format "\\(?:^\\| \\)[^ ]*?\\(\\(?:%s\\)*\\)"
                                company-dabbrev-char-regexp)

--- a/company-elisp.el
+++ b/company-elisp.el
@@ -94,7 +94,7 @@ first in the candidates list."
      (when (> depth 0)
        (save-excursion
          (up-list (- depth))
-         (when (looking-at company-elisp-defuns-regexp)
+         (when (looking-at-p company-elisp-defuns-regexp)
            (forward-char)
            (forward-sexp 1)
            (unless (= (point) start)
@@ -122,21 +122,21 @@ first in the candidates list."
                                         (<= (point) pos)))
                   (skip-chars-forward " \t\n")
                   (cond
-                   ((looking-at (if functions-p
+                   ((looking-at-p (if functions-p
                                     company-elisp-fun-binding-regexp
                                   company-elisp-var-binding-regexp))
                     (down-list 1)
                     (condition-case nil
                         (dotimes (_ company-elisp-parse-limit)
                           (save-excursion
-                            (when (looking-at "[ \t\n]*(")
+                            (when (looking-at-p "[ \t\n]*(")
                               (down-list 1))
                             (when (looking-at regexp)
                               (cl-pushnew (match-string-no-properties 1) res)))
                           (forward-sexp))
                       (scan-error nil)))
                    ((unless functions-p
-                      (looking-at company-elisp-var-binding-regexp-1))
+                      (looking-at-p company-elisp-var-binding-regexp-1))
                     (down-list 1)
                     (when (looking-at regexp)
                       (cl-pushnew (match-string-no-properties 1) res)))))))))
@@ -181,7 +181,7 @@ first in the candidates list."
   (save-excursion
     (and (prog1 (search-backward "(")
            (forward-char 1))
-         (looking-at company-elisp-var-binding-regexp))))
+         (looking-at-p company-elisp-var-binding-regexp))))
 
 (defun company-elisp--doc (symbol)
   (let* ((symbol (intern symbol))

--- a/company.el
+++ b/company.el
@@ -1108,7 +1108,7 @@ Matching is limited to the current line."
 (defun company-grab-symbol ()
   "If point is at the end of a symbol, return it.
 Otherwise, if point is not inside a symbol, return an empty string."
-  (if (looking-at "\\_>")
+  (if (looking-at-p "\\_>")
       (buffer-substring (point) (save-excursion (skip-syntax-backward "w_")
                                                 (point)))
     (unless (and (char-after) (memq (char-syntax (char-after)) '(?w ?_)))
@@ -1117,7 +1117,7 @@ Otherwise, if point is not inside a symbol, return an empty string."
 (defun company-grab-word ()
   "If point is at the end of a word, return it.
 Otherwise, if point is not inside a symbol, return an empty string."
-  (if (looking-at "\\>")
+  (if (looking-at-p "\\>")
       (buffer-substring (point) (save-excursion (skip-syntax-backward "w")
                                                 (point)))
     (unless (and (char-after) (eq (char-syntax (char-after)) ?w))

--- a/test/template-tests.el
+++ b/test/template-tests.el
@@ -107,7 +107,7 @@
       (insert text)
       (company-template-objc-templatify text)
       (should (equal "createBookWithTitle:arg0 andAuthor:arg1" (buffer-string)))
-      (should (looking-at "arg0"))
+      (should (looking-at-p "arg0"))
       (should (null (overlay-get (company-template-field-at) 'display))))))
 
 (ert-deftest company-template-objc-templatify ()


### PR DESCRIPTION
`looking-at-p` does not change match data and so should be a bit faster.