### PR TITLE
Let company-ispell-dictionary be compatible with the ~user notation.

### DIFF
--- a/company-ispell.el
+++ b/company-ispell.el
@@ -39,7 +39,8 @@
 
 (defcustom company-ispell-dictionary nil
   "Dictionary to use for `company-ispell'.
-If nil, use `ispell-complete-word-dict'."
+
+If nil, use `ispell-complete-word-dict' or `ispell-alternate-dictionary'."
   :type '(choice (const :tag "default (nil)" nil)
                  (file :tag "dictionary" t))
   :set #'company--set-dictionary)
@@ -58,9 +59,12 @@ If nil, use `ispell-complete-word-dict'."
   company-ispell-available)
 
 (defun company--ispell-dict ()
-  (or company-ispell-dictionary
-      ispell-complete-word-dict
-      ispell-alternate-dictionary))
+  "Determine which dictionary to use."
+  (let ((dict (or company-ispell-dictionary
+                  ispell-complete-word-dict
+                  ispell-alternate-dictionary)))
+    (when dict
+      (expand-file-name dict))))
 
 ;;;###autoload
 (defun company-ispell (command &optional arg &rest _ignored)


### PR DESCRIPTION
Hi,

Currently, the company-ispell dictionary path doesn't allow to have a `~` in it. For example, with below setting:

```elisp
(setq company-ispell-dictionary "~/.emacs.d/data/misc/english-words.txt")
```

It will error out with message:

```
Company: An error occurred in auto-begin
Company: backend (company-dabbrev company-ispell) error "grep error: look: ~/.emacs.d/data/misc/english-words.txt: No such file or directory" with args (candidates he)
```

So I'm making this PR trying to fix that.
