### PR TITLE
Replace `string-match` with `string-match-p` when appropriate and use `string-empty-p` helper

### DIFF
--- a/company-dabbrev-code.el
+++ b/company-dabbrev-code.el
@@ -78,7 +78,7 @@ also `company-dabbrev-code-time-limit'."
 (defun company-dabbrev-code--make-regexp (prefix)
   (let ((prefix-re
          (cond
-          ((equal prefix "")
+          ((string-empty-p prefix)
            "\\([a-zA-Z]\\|\\s_\\)")
           ((not company-dabbrev-code-completion-styles)
            (regexp-quote prefix))

--- a/company-files.el
+++ b/company-files.el
@@ -53,7 +53,7 @@ Set this to nil to disable that behavior."
                         (lambda (s1 s2) (string-lessp (downcase s1) (downcase s2))))))
         (when company-files-exclusions
           (setq comp (company-files--exclusions-filtered comp)))
-        (if (equal prefix "")
+        (if (string-empty-p prefix)
             (delete "../" (delete "./" comp))
           comp))
     (file-error nil)))

--- a/company-ispell.el
+++ b/company-ispell.el
@@ -81,7 +81,7 @@ If nil, use `ispell-complete-word-dict' or `ispell-alternate-dictionary'."
                                   (lambda () (ispell-lookup-words "" dict))
                                   :check-tag dict))
             (completion-ignore-case t))
-       (if (string= arg "")
+       (if (string-empty-p arg)
            ;; Small optimization.
            all-words
          (company-substitute-prefix

--- a/company-semantic.el
+++ b/company-semantic.el
@@ -140,7 +140,7 @@ and `c-electric-colon', for automatic completion right after \">\" and
                  (memq major-mode company-semantic-modes)
                  (not (company-in-string-or-comment))
                  (or (company-semantic--prefix) 'stop)))
-    (candidates (if (and (equal arg "")
+    (candidates (if (and (string-empty-p arg)
                          (not (looking-back "->\\|\\.\\|::" (- (point) 2))))
                     (company-semantic-completions-raw arg)
                   (company-semantic-completions arg)))
@@ -151,7 +151,7 @@ and `c-electric-colon', for automatic completion right after \">\" and
     (doc-buffer (company-semantic-doc-buffer
                  (assoc arg company-semantic--current-tags)))
     ;; Because "" is an empty context and doesn't return local variables.
-    (no-cache (equal arg ""))
+    (no-cache (string-empty-p arg))
     (duplicates t)
     (location (let ((tag (assoc arg company-semantic--current-tags)))
                 (when (buffer-live-p (semantic-tag-buffer tag))

--- a/company.el
+++ b/company.el
@@ -2145,8 +2145,8 @@ For more details see `company-insertion-on-trigger' and
          (if (consp company-insertion-triggers)
              (memq (char-syntax (string-to-char input))
                    company-insertion-triggers)
-           (string-match (regexp-quote (substring input 0 1))
-                         company-insertion-triggers)))))
+           (string-match-p (regexp-quote (substring input 0 1))
+                           company-insertion-triggers)))))
 
 (defun company--incremental-p ()
   (and (> (point) company-point)
@@ -2508,7 +2508,7 @@ each one wraps a part of the input string."
          (company-candidates-predicate
           (and (not (string= re ""))
                company-search-filtering
-               (lambda (candidate) (string-match re candidate))))
+               (lambda (candidate) (string-match-p re candidate))))
          (cc (company-calculate-candidates company-prefix
                                            (company-call-backend 'ignore-case))))
     (unless cc (user-error "No match"))

--- a/company.el
+++ b/company.el
@@ -1991,7 +1991,7 @@ Keywords and function definition names are ignored."
             (cl-delete-if
              (lambda (candidate)
                (goto-char w-start)
-               (when (and (not (equal candidate ""))
+               (when (and (not (string-empty-p candidate))
                           (search-forward candidate w-end t)
                           ;; ^^^ optimize for large lists where most elements
                           ;; won't have a match.
@@ -4111,7 +4111,7 @@ Delay is determined by `company-tooltip-idle-delay'."
                                (substring completion 1))))
 
     (and (equal pos (point))
-         (not (equal completion ""))
+         (not (string-empty-p completion))
          (add-text-properties 0 1 '(cursor 1) completion))
 
     (let* ((beg pos)
@@ -4298,7 +4298,7 @@ Delay is determined by `company-tooltip-idle-delay'."
               "}"))))
 
 (defun company-echo-hide ()
-  (unless (equal company-echo-last-msg "")
+  (unless (string-empty-p company-echo-last-msg)
     (setq company-echo-last-msg "")
     (company-echo-show)))
 

--- a/company.el
+++ b/company.el
@@ -2506,7 +2506,7 @@ each one wraps a part of the input string."
 (defun company--search-update-predicate (ss)
   (let* ((re (funcall company-search-regexp-function ss))
          (company-candidates-predicate
-          (and (not (string= re ""))
+          (and (not (string-empty-p re))
                company-search-filtering
                (lambda (candidate) (string-match-p re candidate))))
          (cc (company-calculate-candidates company-prefix
@@ -2524,7 +2524,7 @@ each one wraps a part of the input string."
 
 (defun company--search-assert-input ()
   (company--search-assert-enabled)
-  (when (string= company-search-string "")
+  (when (string-empty-p company-search-string)
     (user-error "Empty search string")))
 
 (defun company-search-repeat-forward ()
@@ -2577,7 +2577,7 @@ each one wraps a part of the input string."
 (defun company-search-delete-char ()
   (interactive)
   (company--search-assert-enabled)
-  (if (string= company-search-string "")
+  (if (string-empty-p company-search-string)
       (ding)
     (let ((ss (substring company-search-string 0 -1)))
       (when company-search-filtering
@@ -3427,7 +3427,7 @@ If SHOW-VERSION is non-nil, show the version in the echo area."
                                 nil line))
     (when (let ((re (funcall company-search-regexp-function
                              company-search-string)))
-            (and (not (string= re ""))
+            (and (not (string-empty-p re))
                  (string-match re value)))
       (pcase-dolist (`(,mbeg . ,mend) (company--search-chunks))
         (let ((beg (+ margin mbeg))


### PR DESCRIPTION
This is a minor refactoring.

1.-st commit uses `string-match-p` if match data is unused. The places of replacement were manually examined to make sure it is the case.
2.nd commit should be safe and straightworward replacement of `(string= … "")` with `string-empty-p`
3.rd commit is similar to 2-nd one, except we getting rid of `(equal … "")`. Due to `(equal)` allowing for its arg to be of any type, each changed line was manually examined to make sure that code around it expects a string, so the parameter must be a string as well and not an arbitrary type.