### PR TITLE
company-plainify: Only concat string when satisfying stringp

### DIFF
--- a/company.el
+++ b/company.el
@@ -3343,7 +3343,7 @@ If SHOW-VERSION is non-nil, show the version in the echo area."
 
 (defun company-plainify (str)
   (let ((prefix (get-text-property 0 'line-prefix str)))
-    (when prefix ; Keep the original value unmodified, for no special reason.
+    (when (stringp prefix) ; Keep the original value unmodified, for no special reason.
       (setq str (concat prefix str))
       (remove-text-properties 0 (length str) '(line-prefix) str)))
   (let* ((pieces (split-string str "\t"))


### PR DESCRIPTION
Currently `company-plainify` expects `line-prefix` to be a string and will fail otherwise. The `line-prefix` text property can be values other than a string, e.g. `(space :width 5)`.

This adds the condition to only attempt to concat the prefix if it is indeed a string.