### PR TITLE
Async no cache flicker

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,14 @@
 
 # Next
 
+* Improved behavior when user types new character while completion is being
+  computed: better performance, less blinking (in the rare cases when it still
+  happened). The improvement extends to native async backends and to
+  `company-capf`.
+* As such `company-capf` now interrupts computation on new user
+  input. Completion tables that are incompatible with this behavior should get
+  updated: bind `inhibit-quit` to non-nil around their sensitive sections, or
+  simply around the whole implementation (as a fallback).
 * `company-elisp` has been removed.  It's not needed since Emacs 24.4, with all
   of its features having been incorporated into the built-in Elisp completion.
 * `company-files` shows shorter completions.  Previously, the popup spanned

--- a/company-capf.el
+++ b/company-capf.el
@@ -189,12 +189,10 @@ so we can't just use the preceding variable instead.")
                      table pred))))
     (company-capf--save-current-data res meta)
     (when res
-      (let* ((interrupt (plist-get (nthcdr 4 res) :company-use-while-no-input))
-             (candidates (company-capf--candidates-1 input table pred
+      (let* ((candidates (company-capf--candidates-1 input table pred
                                                      (length input)
                                                      meta
-                                                     (and non-essential
-                                                          interrupt)))
+                                                     non-essential))
              (sortfun (cdr (assq 'display-sort-function meta)))
              (last (last candidates))
              (base-size (and (numberp (cdr last)) (cdr last))))

--- a/company-capf.el
+++ b/company-capf.el
@@ -193,7 +193,8 @@ so we can't just use the preceding variable instead.")
              (candidates (company-capf--candidates-1 input table pred
                                                      (length input)
                                                      meta
-                                                     interrupt))
+                                                     (and non-essential
+                                                          interrupt)))
              (sortfun (cdr (assq 'display-sort-function meta)))
              (last (last candidates))
              (base-size (and (numberp (cdr last)) (cdr last))))

--- a/test/capf-tests.el
+++ b/test/capf-tests.el
@@ -1,6 +1,6 @@
 ;;; capf-tests.el --- company tests for the company-capf backend  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2018-2019, 2021-2023  Free Software Foundation, Inc.
+;; Copyright (C) 2018-2019, 2021-2024  Free Software Foundation, Inc.
 
 ;; Author: João Távora <joaotavora@gmail.com>
 ;; Keywords:
@@ -140,6 +140,30 @@
         #("with-current-buffer"
           0 14 (face (company-tooltip-common company-tooltip)); "with-current-b"
           14 19 (face company-tooltip)))))))                ; "uffer"
+
+(ert-deftest company-capf-interrupted-on-input ()
+  (should
+   (eq
+    (catch 'interrupted
+      (with-temp-buffer
+        (let ((completion-at-point-functions
+               (list (lambda ()
+                       (list 1 1 obarray :company-use-while-no-input t))))
+              (unread-command-events '(?a)))
+          (company-capf 'candidates "a")
+          (error "Not reachable"))))
+    'new-input)))
+
+(ert-deftest company-capf-uninterrupted ()
+  (should
+   (equal
+    (with-temp-buffer
+      (let ((completion-at-point-functions
+             (list (lambda ()
+                     (list 1 1 '("abcd" "ae" "be") t))))
+            (unread-command-events '(?a)))
+        (company-capf 'candidates "b")))
+    '("be"))))
 
 (provide 'capf-tests)
 ;;; capf-tests.el ends here

--- a/test/capf-tests.el
+++ b/test/capf-tests.el
@@ -149,7 +149,8 @@
         (let ((completion-at-point-functions
                (list (lambda ()
                        (list 1 1 obarray :company-use-while-no-input t))))
-              (unread-command-events '(?a)))
+              (unread-command-events '(?a))
+              (non-essential t))
           (company-capf 'candidates "a")
           (error "Not reachable"))))
     'new-input)))


### PR DESCRIPTION
* Internal handling of input interruption with throw-catch that ensures completion is not aborted.
* An interface to opt into `while-no-input` for company-capf which reuses the mechanism.
* As an semi-private feature, the completion table can just `(throw 'interrupted 'new-input)` instead, if it detects new input using its own methods.

~I suppose the main thing left to decide is whether `while-no-input` should be opt-in or opt-out for the capf backend.~

EDIT: just opt-out: see NEWS.

