### PR TITLE
abbrev backend: use abbrev--active-tables to get all tables

### DIFF
--- a/company-abbrev.el
+++ b/company-abbrev.el
@@ -41,9 +41,11 @@
     (interactive (company-begin-backend 'company-abbrev
                                         'company-abbrev-insert))
     (prefix (company-grab-symbol))
-    (candidates (nconc
-                 (delete "" (all-completions arg global-abbrev-table))
-                 (delete "" (all-completions arg local-abbrev-table))))
+    (candidates (apply
+                 #'nconc
+                 (mapcar (lambda (table)
+                           (delete "" (all-completions arg table)))
+                         (abbrev--active-tables))))
     (kind 'snippet)
     (meta (abbrev-expansion arg))
     (post-completion (expand-abbrev))))


### PR DESCRIPTION
previous, tables in `abbrev-minor-mode-table-alist` was not considered