### PR TITLE
Make the user of while-no-input in company-capf opt-in

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,13 +4,11 @@
 
 * Improved behavior when user types new character while completion is being
   computed: better performance, less blinking (in the rare cases when it still
-  happened). The improvement extends to native async backends and to
+  happened). This affects native async backends and is opt-in with
   `company-capf`.
-* As such `company-capf` now interrupts computation on new user
-  input. Completion tables that are incompatible with this behavior should get
-  updated: bind `inhibit-quit` to non-nil around their sensitive sections, or
-  simply around the whole implementation (e.g. using
-  `cape-capf-noninterruptible` from [cape](https://github.com/minad/cape/)).
+* For that, `company-capf` supports interrupting computation on new user
+  input. Completion functions that want to take advantage of this behavior
+  should include `:company-use-while-no-input` in the returned properties list.
 * `company-elisp` has been removed.  It's not needed since Emacs 24.4, with all
   of its features having been incorporated into the built-in Elisp completion.
 * `company-files` shows shorter completions.  Previously, the popup spanned

--- a/company-capf.el
+++ b/company-capf.el
@@ -189,10 +189,12 @@ so we can't just use the preceding variable instead.")
                      table pred))))
     (company-capf--save-current-data res meta)
     (when res
-      (let* ((candidates (company-capf--candidates-1 input table pred
+      (let* ((interrupt (plist-get (nthcdr 4 res) :company-use-while-no-input))
+             (candidates (company-capf--candidates-1 input table pred
                                                      (length input)
                                                      meta
-                                                     non-essential))
+                                                     (and non-essential
+                                                          interrupt)))
              (sortfun (cdr (assq 'display-sort-function meta)))
              (last (last candidates))
              (base-size (and (numberp (cdr last)) (cdr last))))


### PR DESCRIPTION
The problem described in https://github.com/joaotavora/eglot/discussions/1127#discussioncomment-7698442 still seems to apply to the Eglot version that comes with Emacs 29.1-29.4, and so might affect a fair number of users, given that an "ELPA core" package doesn't update by default (until the user triggers the first update manually), and a lot of users won't.

I went through the thread, but only managed to reproduce it once (with Emacs 29.1), and not for the lack of trying.

Even if being interruption-safe is the "proper" behavior for completion functions, it seems that at least for this case exposing the problem (i.e. using a capf function inside interrupting context) doesn't really help to have it fixed - and not for the lack of trying.

So it the right move seems to be the change to opt-in for now, and the re-evaluate when the 29 version of Emacs has been superseded, and also see whether some/many/most capfs have adopted the new property, indicating that they find this feature helpful.

The downside to the change seems minor: as you @minad have noted, only a handful of CAPFs constitute the majority of usage, and both lsp-mode and Eglot currently have their own solution to interruption on new input (so their performance should stay unchanged).  But this might help them migrate, too.