### PR TITLE
company-dabbrev/-code: allows company-dabbrev(-code)-other-buffers a function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 # Next
 
+* `company-dabbrev-other-buffers` and `company-dabbrev-code-other-buffers` can
+  now take a function as its value (#[1485](https://github.com/company-mode/company-mode/issues/1485))
 * Completion works in the middle of a symbol
   (#[1474](https://github.com/company-mode/company-mode/pull/1474)).
 * New user option `company-inhibit-inside-symbols`. Set it to `t` to switch

--- a/company-dabbrev-code.el
+++ b/company-dabbrev-code.el
@@ -48,13 +48,16 @@ complete only symbols, not text in comments or strings.  In other modes
 (defcustom company-dabbrev-code-other-buffers t
   "Determines whether `company-dabbrev-code' should search other buffers.
 If `all', search all other buffers, except the ignored ones.  If t, search
-buffers with the same major mode.  If `code', search all buffers with major
-modes in `company-dabbrev-code-modes', or derived from one of them.  See
-also `company-dabbrev-code-time-limit'."
+buffers with the same major mode.  If `code', search all
+buffers with major modes in `company-dabbrev-code-modes', or derived from one of
+them.  This can also be a function that take a parameter of the current
+buffer and returns a list of major modes to search.
+See also `company-dabbrev-code-time-limit'."
   :type '(choice (const :tag "Off" nil)
                  (const :tag "Same major mode" t)
                  (const :tag "Code major modes" code)
-                 (const :tag "All" all)))
+                 (const :tag "All" all)
+                 (function :tag "Function to return similar major-modes" group)))
 
 (defcustom company-dabbrev-code-time-limit .1
   "Determines how long `company-dabbrev-code' should look for matches."
@@ -132,6 +135,7 @@ comments or strings."
          (pcase company-dabbrev-code-other-buffers
            (`t (list major-mode))
            (`code company-dabbrev-code-modes)
+           ((pred functionp) (funcall company-dabbrev-code-other-buffers (current-buffer)))
            (`all `all))
          (not company-dabbrev-code-everywhere)))
       :expire t

--- a/company-dabbrev.el
+++ b/company-dabbrev.el
@@ -35,10 +35,13 @@
 (defcustom company-dabbrev-other-buffers 'all
   "Determines whether `company-dabbrev' should search other buffers.
 If `all', search all other buffers, except the ignored ones.  If t, search
-buffers with the same major mode.  See also `company-dabbrev-time-limit'."
+buffers with the same major mode.  This can also be a function that take a
+parameter of the current buffer and returns a list of major modes to search.
+See also `company-dabbrev-time-limit'."
   :type '(choice (const :tag "Off" nil)
                  (const :tag "Same major mode" t)
-                 (const :tag "All" all)))
+                 (const :tag "All" all)
+                 (function :tag "Function to return similar major-modes" group)))
 
 (defcustom company-dabbrev-ignore-buffers "\\`[ *]"
   "Regexp matching the names of buffers to ignore.
@@ -196,6 +199,7 @@ This variable affects both `company-dabbrev' and `company-dabbrev-code'."
                            company-dabbrev-time-limit
                            (pcase company-dabbrev-other-buffers
                              (`t (list major-mode))
+                             ((pred functionp) (funcall company-dabbrev-other-buffers (current-buffer)))
                              (`all `all))))
 
 ;;;###autoload


### PR DESCRIPTION
This allows a similar functionality to `dabbrev-friend-buffer-function` for `company-dabbrev(-code)-other-buffers`.