### PR TITLE
company-complete-common: Generalized "expand common" behavior

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,11 @@
 
 # Next
 
-* `company-complete-common` now performs generalized "expand common part"
-  completion when the current backend supports that.  In particular, for
-  `completion-at-point-functions` it queries `completion-try-completion`.
+* `company-complete-common` now performs generalized ([expand common
+  part](https://github.com/company-mode/company-mode/pull/1488)) completion when
+  the backend supports that. In particular, for `completion-at-point-functions`
+  it queries `completion-try-completion`. `company-dabbrev-code` and
+  `company-etags` also do that when `completion-styles` support is enabled.
 * `company-dabbrev-other-buffers` and `company-dabbrev-code-other-buffers` can
   now take a function as its value (#[1485](https://github.com/company-mode/company-mode/issues/1485))
 * Completion works in the middle of a symbol

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 # Next
 
+* `company-complete-common` now performs generalized "expand common part"
+  completion now when the current backend support that.  In particular, for
+  `completion-at-point-functions` it queries `completion-try-completion`.
 * `company-dabbrev-other-buffers` and `company-dabbrev-code-other-buffers` can
   now take a function as its value (#[1485](https://github.com/company-mode/company-mode/issues/1485))
 * Completion works in the middle of a symbol

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 # Next
 
 * `company-complete-common` now performs generalized "expand common part"
-  completion now when the current backend support that.  In particular, for
+  completion when the current backend supports that.  In particular, for
   `completion-at-point-functions` it queries `completion-try-completion`.
 * `company-dabbrev-other-buffers` and `company-dabbrev-code-other-buffers` can
   now take a function as its value (#[1485](https://github.com/company-mode/company-mode/issues/1485))

--- a/company-capf.el
+++ b/company-capf.el
@@ -19,7 +19,6 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
 
-
 ;;; Commentary:
 ;;
 ;; The CAPF back-end provides a bridge to the standard

--- a/company-capf.el
+++ b/company-capf.el
@@ -164,7 +164,25 @@ so we can't just use the preceding variable instead.")
      (company--capf-post-completion arg))
     (`adjust-boundaries
      company-capf--current-boundaries)
+    (`expand-common
+     (company-capf--expand-common arg (car rest)))
     ))
+
+(defun company-capf--expand-common (prefix suffix)
+  (let* ((data company-capf--current-completion-data)
+         (table (nth 3 data))
+         (pred (plist-get (nthcdr 4 data) :predicate))
+         (res
+          (completion-try-completion (concat prefix suffix)
+                                     table pred (length prefix)
+                                     company-capf--current-completion-metadata)))
+    (cond
+     ((memq res '(t nil))
+      (cons prefix suffix))
+     (t
+      (cons
+       (substring (car res) 0 (cdr res))
+       (substring (car res) (cdr res)))))))
 
 (defun company-capf--annotation (arg)
   (let* ((f (or (plist-get (nthcdr 4 company-capf--current-completion-data)

--- a/company-capf.el
+++ b/company-capf.el
@@ -170,18 +170,9 @@ so we can't just use the preceding variable instead.")
 (defun company-capf--expand-common (prefix suffix)
   (let* ((data company-capf--current-completion-data)
          (table (nth 3 data))
-         (pred (plist-get (nthcdr 4 data) :predicate))
-         (res
-          (completion-try-completion (concat prefix suffix)
-                                     table pred (length prefix)
-                                     company-capf--current-completion-metadata)))
-    (cond
-     ((memq res '(t nil))
-      (cons prefix suffix))
-     (t
-      (cons
-       (substring (car res) 0 (cdr res))
-       (substring (car res) (cdr res)))))))
+         (pred (plist-get (nthcdr 4 data) :predicate)))
+    (company--capf-expand-common prefix suffix table pred
+                                 company-capf--current-completion-metadata)))
 
 (defun company-capf--annotation (arg)
   (let* ((f (or (plist-get (nthcdr 4 company-capf--current-completion-data)

--- a/company.el
+++ b/company.el
@@ -3670,13 +3670,6 @@ If SHOW-VERSION is non-nil, show the version in the echo area."
 
 (defun company--common-or-matches (value &optional suffix)
   (let ((matches (company-call-backend 'match value)))
-    (when (and matches
-               company-common
-               (listp matches)
-               (= 1 (length matches))
-               (= 0 (caar matches))
-               (> (length company-common) (cdar matches)))
-      (setq matches nil))
     (when (integerp matches)
       (setq matches `((0 . ,matches))))
     (or matches

--- a/company.el
+++ b/company.el
@@ -1472,7 +1472,7 @@ be recomputed when this value changes."
                               (aref (car (nth 2 tuple)) beg)))
                  (cl-incf beg))
                (while (and (< end max-end)
-                           (= (aref prefix (- bslen end 1))
+                           (= (aref suffix (- bslen end 1))
                               (aref (cdr (nth 2 tuple))
                                     (- rep-suffix-len end 1))))
                  (cl-incf end))
@@ -1495,6 +1495,7 @@ be recomputed when this value changes."
        ;; change the buffer contents first, then fetch `candidates' for each,
        ;; and revert at the end.  Might be error-prone.
        (and
+        choice
         (cl-every
          (lambda (replacement)
            (and

--- a/company.el
+++ b/company.el
@@ -1669,9 +1669,8 @@ update if FORCE-UPDATE."
     (setq company-common
           (if (cdr company-candidates)
               (let ((common (try-completion "" company-candidates)))
-                (when (string-prefix-p company-prefix common
-                                       completion-ignore-case)
-                  common))
+                (and (stringp common)
+                     common))
             (car company-candidates)))))
 
 (defun company-calculate-candidates (prefix ignore-case suffix)

--- a/company.el
+++ b/company.el
@@ -1242,6 +1242,18 @@ MAX-LEN is how far back to try to match the IDLE-BEGIN-AFTER-RE regexp."
       (:boundaries . ,(cons (substring prefix base-size)
                             (substring suffix 0 (cdr bounds)))))))
 
+(defun company--capf-expand-common (prefix suffix table &optional pred metadata)
+  (let* ((res
+          (completion-try-completion (concat prefix suffix)
+                                     table pred (length prefix) metadata)))
+    (cond
+     ((memq res '(t nil))
+      (cons prefix suffix))
+     (t
+      (cons
+       (substring (car res) 0 (cdr res))
+       (substring (car res) (cdr res)))))))
+
 (defvar company--cache (make-hash-table :test #'equal :size 10))
 
 (cl-defun company-cache-fetch (key

--- a/company.el
+++ b/company.el
@@ -3048,7 +3048,7 @@ For use in the `select-mouse' frontend action.  `let'-bound.")
     (let ((result (nth company-selection company-candidates)))
       (company-finish result))))
 
-(defun company--expand-common (prefix suffix &optional current-prefix)
+(defun company--expand-common (prefix suffix)
   (let ((expansion (company-call-backend 'expand-common prefix suffix)))
     (unless expansion
       ;; Backend doesn't implement this, try emulating.
@@ -3078,8 +3078,7 @@ For use in the `select-mouse' frontend action.  `let'-bound.")
                 (cons (concat
                        (substring prefix
                                   0
-                                  (- (length (or current-prefix
-                                                 prefix))
+                                  (- (length prefix)
                                      (length boundaries-prefix)))
                        common)
                       suffix))
@@ -3094,8 +3093,7 @@ For use in the `select-mouse' frontend action.  `let'-bound.")
              (equal company-common (car company-candidates)))
         (company-complete-selection)
       (let ((expansion (company--expand-common company-prefix
-                                               company-suffix
-                                               company-candidates)))
+                                               company-suffix)))
         (when (eq expansion 'no-match)
           (user-error "No matches for the current input"))
         (unless (equal (car expansion) company-prefix)

--- a/company.el
+++ b/company.el
@@ -1422,7 +1422,6 @@ be recomputed when this value changes."
                                 (if (company--good-prefix-p bp min-length)
                                     (setq backend-prefix (company--prefix-str bp)
                                           suffix (company--suffix-str bp))
-                                  t
                                   (push backend company--multi-uncached-backends)
                                   nil))
                          collect (cons (funcall backend 'candidates backend-prefix suffix)

--- a/company.el
+++ b/company.el
@@ -3057,10 +3057,13 @@ For use in the `select-mouse' frontend action.  `let'-bound.")
              ;; Assuming that boundaries don't vary between completions here.
              ;; If they do, the backend should have a custom `expand-common'.
              (boundaries-prefix (car (company--boundaries)))
+             (completion-ignore-case (company-call-backend 'ignore-case))
              (trycmp (try-completion boundaries-prefix candidates))
              (common (if (eq trycmp t) (car candidates) trycmp))
              (max-len (when (and common
-                                 (cl-every (lambda (s) (string-suffix-p suffix s))
+                                 (cl-every (lambda (s) (string-suffix-p
+                                                   suffix s
+                                                   completion-ignore-case))
                                            candidates))
                         (-
                          (apply #'min

--- a/company.el
+++ b/company.el
@@ -2959,7 +2959,8 @@ For use in the `select-mouse' frontend action.  `let'-bound.")
                                                 (min max-len (length company-common)))
                                    company-common)))
             (setq expansion (cons (if (string-prefix-p company-prefix
-                                                       company-common)
+                                                       company-common
+                                                       t)
                                       company-common
                                     company-prefix)
                                   company-suffix))))

--- a/company.el
+++ b/company.el
@@ -2968,14 +2968,23 @@ For use in the `select-mouse' frontend action.  `let'-bound.")
                              (apply #'min
                                     (mapcar #'length company-candidates))
                              (length company-suffix))))
-                 (company-common (if max-len
-                                     (substring company-common 0
-                                                (min max-len (length company-common)))
-                                   company-common)))
-            (setq expansion (cons (if (string-prefix-p company-prefix
-                                                       company-common
+                 (common (if max-len
+                             (substring company-common 0
+                                        (min max-len (length company-common)))
+                                   company-common))
+                 ;; We're making an assumption that boundaries don't vary
+                 ;; between completions here. If they do, the backend should
+                 ;; have a custom implementation for `expand-common'.
+                 (boundaries-prefix (car (company--boundaries))))
+            (setq expansion (cons (if (string-prefix-p boundaries-prefix
+                                                       common
                                                        t)
-                                      company-common
+                                      (concat
+                                       (substring company-prefix
+                                                  0
+                                                  (- (length company-prefix)
+                                                     (length boundaries-prefix)))
+                                       common)
                                     company-prefix)
                                   company-suffix))))
         (unless (equal (car expansion) company-prefix)

--- a/company.el
+++ b/company.el
@@ -1419,8 +1419,10 @@ be recomputed when this value changes."
           (or (not backends-after-with)
               (unless (memq backend backends-after-with)
                 (setq backends-after-with nil)))
-          (when (> (length (company--prefix-str entity))
-                   (length prefix))
+          (when (or
+                 (null prefix)
+                 (> (length (company--prefix-str entity))
+                    (length prefix)))
             (setq prefix (company--prefix-str entity)))
           (when (> (length (company--suffix-str entity))
                    (length suffix))

--- a/company.el
+++ b/company.el
@@ -3067,7 +3067,12 @@ For use in the `select-mouse' frontend action.  `let'-bound.")
   (let ((expansion (company-call-backend 'expand-common prefix suffix)))
     (unless expansion
       ;; Backend doesn't implement this, try emulating.
-      (let* ((max-len (when (and company-common
+      (let* (;; Assuming that boundaries don't vary between completions here.
+             ;; If they do, the backend should have a custom `expand-common'.
+             (boundaries-prefix (car (company--boundaries)))
+             (trycmp (try-completion boundaries-prefix candidates))
+             (common (if (eq trycmp t) (car candidates) trycmp))
+             (max-len (when (and common
                                  (cl-every (lambda (s) (string-suffix-p suffix s))
                                            candidates))
                         (-
@@ -3075,13 +3080,9 @@ For use in the `select-mouse' frontend action.  `let'-bound.")
                                 (mapcar #'length candidates))
                          (length suffix))))
              (common (if max-len
-                         (substring company-common 0
-                                    (min max-len (length company-common)))
-                       company-common))
-             ;; We're making an assumption that boundaries don't vary
-             ;; between completions here. If they do, the backend should
-             ;; have a custom implementation for `expand-common'.
-             (boundaries-prefix (car (company--boundaries))))
+                         (substring common 0
+                                    (min max-len (length common)))
+                       common)))
         (setq expansion (cons (if (string-prefix-p boundaries-prefix
                                                    common
                                                    t)

--- a/company.el
+++ b/company.el
@@ -397,8 +397,8 @@ return value should be a list of candidates that match the prefix.
 
 Non-prefix matches are also supported (candidates that don't start with the
 prefix, but match it in some backend-defined way).  Backends that use this
-feature must disable cache (return t to `no-cache') and might also want to
-respond to `match'.
+feature must disable cache (return t in response to `no-cache') and might
+also want to handle `match'.
 
 Optional commands
 =================

--- a/test/async-tests.el
+++ b/test/async-tests.el
@@ -128,7 +128,7 @@
                                  (lambda (command)
                                    (should (eq command 'prefix))
                                    "foo"))))
-      (should (equal "foo" (company-call-backend-raw 'prefix))))
+      (should (equal '("foo" nil 3) (company-call-backend-raw 'prefix))))
     (let ((company-backend (list (lambda (_command)
                                    (cons :async
                                          (lambda (cb)
@@ -137,7 +137,7 @@
                                             (lambda () (funcall cb "bar"))))))
                                  (lambda (_command)
                                    "foo"))))
-      (should (equal "bar" (company-call-backend-raw 'prefix))))))
+      (should (equal '("bar" nil 3) (company-call-backend-raw 'prefix))))))
 
 (ert-deftest company-multi-backend-merges-deferred-candidates ()
   (with-temp-buffer

--- a/test/capf-tests.el
+++ b/test/capf-tests.el
@@ -84,8 +84,8 @@
        (company--equal-including-properties
         render
         #("with-timeout-suspend"
-          0 12 (face (company-tooltip-common company-tooltip))   ; "with"
-          12 20 (face company-tooltip)))))))
+          0 7 (face (company-tooltip-common company-tooltip)) ; "with"
+          7 20 (face company-tooltip)))))))
 
 
 ;; Re. "perfect" highlighting of the non-prefix in company-capf matches, it is

--- a/test/core-tests.el
+++ b/test/core-tests.el
@@ -128,6 +128,18 @@
     (company-call-backend 'set-min-prefix 1)
     (should (equal (company-call-backend 'candidates "z") '("a" "b" "c" "d")))))
 
+(ert-deftest company-multi-backend-with-empty-prefixes ()
+  (let ((company-backend
+         (list (lambda (command &optional _ &rest _r)
+                 (cl-case command
+                   (prefix "")
+                   (candidates '("a" "b"))))
+               (lambda (command &optional _ &rest _r)
+                 (cl-case command
+                   (prefix "")
+                   (candidates '("c" "d")))))))
+    (should (equal (company-call-backend 'prefix) '("" nil 0)))))
+
 (ert-deftest company-multi-backend-dispatches-separate-prefix-to-backends ()
   (let ((company-backend
          (list (lambda (command &optional arg &rest _r)

--- a/test/core-tests.el
+++ b/test/core-tests.el
@@ -109,9 +109,9 @@
         company-candidates-cache
         company-common)
     (company-update-candidates '("abc" "def-abc"))
-    (should (null company-common))
+    (should (equal company-common ""))
     (company-update-candidates '("abc" "abe-c"))
-    (should (null company-common))
+    (should (equal company-common "ab"))
     (company-update-candidates '("abcd" "abcde" "abcdf"))
     (should (equal "abcd" company-common))))
 


### PR DESCRIPTION
* New backend action `expand-common`.
* `company-capf` implementation that calls `completion-try-completion` (and support in `company-dabbrev-code` and `company-etags` - when the use of completion styles is enabled in each backend).
* Support for grouped backends returning prefixes/suffixes of different length (resolves #1260).
* Support for `expand-common` in grouped backends as well.

Demo:

[screencast.webm](https://github.com/user-attachments/assets/61d68d98-129b-4249-be20-9aea03a055b6)
