### PR TITLE
Store capf boundaries as markers

### DIFF
--- a/company-capf.el
+++ b/company-capf.el
@@ -162,7 +162,8 @@ so we can't just use the preceding variable instead.")
     (`post-completion
      (company--capf-post-completion arg))
     (`adjust-boundaries
-     company-capf--current-boundaries)
+     (company--capf-boundaries
+      company-capf--current-boundaries))
     (`expand-common
      (company-capf--expand-common arg (car rest)))
     ))
@@ -205,11 +206,13 @@ so we can't just use the preceding variable instead.")
                                                      (and non-essential
                                                           (eq interrupt t))))
              (sortfun (cdr (assq 'display-sort-function meta)))
-             (candidates (assoc-default :completions all-result))
-             (boundaries (assoc-default :boundaries all-result)))
+             (candidates (assoc-default :completions all-result)))
         (setq company-capf--sorted (functionp sortfun))
         (when candidates
-          (setq company-capf--current-boundaries boundaries))
+          (setq company-capf--current-boundaries
+                (company--capf-boundaries-markers
+                 (assoc-default :boundaries all-result)
+                 company-capf--current-boundaries)))
         (when sortfun
           (setq candidates (funcall sortfun candidates)))
         candidates))))

--- a/company-dabbrev-code.el
+++ b/company-dabbrev-code.el
@@ -113,7 +113,8 @@ comments or strings."
                  (company-grab-symbol-parts)))
     (candidates (company-dabbrev--candidates arg (car rest)))
     (adjust-boundaries (and company-dabbrev-code-completion-styles
-                            company-dabbrev--boundaries))
+                            (company--capf-boundaries
+                             company-dabbrev--boundaries)))
     (expand-common (company-dabbrev-code--expand-common arg (car rest)))
     (kind 'text)
     (no-cache t)
@@ -165,7 +166,10 @@ comments or strings."
       (setq res (company--capf-completions
                  prefix suffix
                  table))
-      (setq company-dabbrev--boundaries (assoc-default :boundaries res))
+      (setq company-dabbrev--boundaries
+            (company--capf-boundaries-markers
+             (assoc-default :boundaries res)
+             company-dabbrev--boundaries))
       (assoc-default :completions res))))
 
 (provide 'company-dabbrev-code)

--- a/company-etags.el
+++ b/company-etags.el
@@ -90,7 +90,10 @@ Set it to t or to a list of major modes."
     (and table
          (if company-etags-completion-styles
              (let ((res (company--capf-completions prefix suffix table)))
-               (setq company-etags--boundaries (assoc-default :boundaries res))
+               (setq company-etags--boundaries
+                     (company--capf-boundaries-markers
+                      (assoc-default :boundaries res)
+                      company-etags--boundaries))
                (assoc-default :completions res))
            (all-completions prefix table)))))
 
@@ -125,7 +128,8 @@ Set it to t or to a list of major modes."
                  (company-grab-symbol-parts)))
     (candidates (company-etags--candidates arg (car rest)))
     (adjust-boundaries (and company-etags-completion-styles
-                            company-etags--boundaries))
+                            (company--capf-boundaries
+                             company-etags--boundaries)))
     (expand-common (company-etags--expand-common arg (car rest)))
     (no-cache company-etags-completion-styles)
     (location (let ((tags-table-list (company-etags-buffer-table)))


### PR DESCRIPTION
Minor internal reworking. More edge cases succeed when preview is updated in the middle of fetching completions (the `unhide` handler):

* No jumping after left/right arrow navigation, or deleting a char (don't have to guess which of those happened).
* Consistent behavior between backends which fetch boundaries with completions (capf) and those that parse them out of the input strings (company-files).
* `company--multi-backend-adapter` less dependent on the internal variables of this package (better for `cape`).