### PR TITLE
fix performance issue with projectile running hook on candidate switching

### DIFF
--- a/company.el
+++ b/company.el
@@ -3327,7 +3327,7 @@ from the candidates list.")
         (inhibit-modification-hooks t)
         (dedicated (window-dedicated-p))
         (hscroll (window-hscroll))
-        window-configuration-change-hook)
+        window-configuration-change-hook buffer-list-update-hook)
     (with-current-buffer (get-buffer-create " *company-sps*")
       (unwind-protect
           (progn


### PR DESCRIPTION
Hi, Dmitry! I encountered performance issue on completion candidate switching and discovered that problem is in projectile running something heavy in `buffer-list-update-hook`. This PR helps me to fix this issue.