### PR TITLE
company-capf--candidates: Abort when the underlying capf changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # History of user-visible changes
 
+# Next
+
+* Handle the case when the current c-a-p-f function changes mid-session
+  (#[1494](https://github.com/company-mode/company-mode/pull/1494)).
+
 # 2024-09-23 (1.0.2)
 
 * More reliable cache expiration (at the beginning of completion).

--- a/company-capf.el
+++ b/company-capf.el
@@ -193,15 +193,17 @@ so we can't just use the preceding variable instead.")
       annotation)))
 
 (defun company-capf--candidates (input suffix)
-  (let* ((res (company--capf-data))
+  (let* ((current-capf (car company-capf--current-completion-data))
+         (res (company--capf-data))
          (table (nth 3 res))
          (pred (plist-get (nthcdr 4 res) :predicate))
          (meta (and res
                     (completion-metadata
                      (buffer-substring (nth 1 res) (nth 2 res))
                      table pred))))
-    (company-capf--save-current-data res meta)
-    (when res
+    (when (and res
+               (or (not current-capf)
+                   (equal current-capf (car res))))
       (let* ((interrupt (plist-get (nthcdr 4 res) :company-use-while-no-input))
              (all-result (company-capf--candidates-1 input suffix
                                                      table pred
@@ -212,6 +214,7 @@ so we can't just use the preceding variable instead.")
              (candidates (assoc-default :completions all-result)))
         (setq company-capf--sorted (functionp sortfun))
         (when candidates
+          (company-capf--save-current-data res meta)
           (setq company-capf--current-boundaries
                 (company--capf-boundaries-markers
                  (assoc-default :boundaries all-result)

--- a/test/capf-tests.el
+++ b/test/capf-tests.el
@@ -178,12 +178,13 @@
           (cc2 '("abcz" "abczdef" "abcz123"))
           (comp2
            (lambda ()
-             (list (pos-bol) (point)
-                   (mapcar
-                    (lambda (s)
-                      (concat (buffer-substring (pos-bol) (+ (pos-bol) (current-indentation)))
-                              s))
-                    cc2)))))
+             (let ((bol (line-beginning-position)))
+               (list bol (point)
+                     (mapcar
+                      (lambda (s)
+                        (concat (buffer-substring bol (+ bol (current-indentation)))
+                                s))
+                      cc2))))))
 
      (setq-local completion-at-point-functions
                  (list comp1 comp2))


### PR DESCRIPTION
That cancels completion, forcing the re-fetching of data (after the idle delay) with the new capf.

The result is making sure that completions from one capf aren's displayed where another capf is in force (when that choice is done based on buffer contents). This is probably only relevant with "asynchronous" sources, where the frontends are repainted in the middle of fetching the updated completions.