### PR TITLE
company-finish: Restart completion if entered a new field

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 # Next
 
+* Completion is restarted if it enters a new "field" at the end, as indicated by
+  the `adjust-boundaries` backend action
+  (#[1497](https://github.com/company-mode/company-mode/pull/1497)). This
+  benefits file name (and directory) completion.  The user option
+  `company-files-chop-trailing-slash` has been removed, and the
+  `post-completion` handler in `company-files` has been removed as well.
+
 * Handle the case when the current c-a-p-f function changes mid-session
   (#[1494](https://github.com/company-mode/company-mode/pull/1494)).
 

--- a/company-capf.el
+++ b/company-capf.el
@@ -240,8 +240,7 @@ so we can't just use the preceding variable instead.")
          (exit-function (plist-get (nthcdr 4 res) :exit-function))
          (table (nth 3 res)))
     (if exit-function
-        ;; We can more or less know when the user is done with completion,
-        ;; so we do something different than `completion--done'.
+        ;; Follow the example of `completion--done'.
         (funcall exit-function arg
                  ;; FIXME: Should probably use an additional heuristic:
                  ;; completion-at-point doesn't know when the user picked a
@@ -250,7 +249,7 @@ so we can't just use the preceding variable instead.")
                  ;; RET (or use implicit completion with company-tng).
                  (if (= (car (completion-boundaries arg table nil ""))
                         (length arg))
-                     'sole
+                     'exact
                    'finished)))))
 
 (provide 'company-capf)

--- a/company-files.el
+++ b/company-files.el
@@ -38,14 +38,6 @@ The values should use the same format as `completion-ignored-extensions'."
   :type '(repeat (string :tag "File extension or directory name"))
   :package-version '(company . "0.9.1"))
 
-(defcustom company-files-chop-trailing-slash t
-  "Non-nil to remove the trailing slash after inserting directory name.
-
-This way it's easy to continue completion by typing `/' again.
-
-Set this to nil to disable that behavior."
-  :type 'boolean)
-
 (defun company-files--directory-files (dir prefix)
   ;; Don't use directory-files. It produces directories without trailing /.
   (condition-case _err
@@ -137,11 +129,6 @@ Set this to nil to disable that behavior."
   (and (equal (cdr old) (cdr new))
        (string-prefix-p (car old) (car new))))
 
-(defun company-files--post-completion (arg)
-  (when (and company-files-chop-trailing-slash
-             (company-files--trailing-slash-p arg))
-    (delete-char -1)))
-
 (defun company-files--adjust-boundaries (_file prefix suffix)
   (cons
    (file-name-nondirectory prefix)
@@ -162,7 +149,6 @@ File paths with spaces are only supported inside strings."
      (company-files--adjust-boundaries arg (nth 0 rest) (nth 1 rest)))
     (location (cons (dired-noselect
                      (file-name-directory (directory-file-name arg))) 1))
-    (post-completion (company-files--post-completion arg))
     (kind (if (string-suffix-p "/" arg) 'folder 'file))
     (sorted t)
     (no-cache t)))

--- a/company.el
+++ b/company.el
@@ -2598,6 +2598,7 @@ For more details see `company-insertion-on-trigger' and
          (delete-region (point) (+ (point) (length suffix))))
     (let ((tick (buffer-chars-modified-tick))
           (backend company-backend))
+      ;; Call backend's `post-completion' and run other hooks, then exit.
       (company-cancel result)
       ;; Try restarting completion, to see if we moved into a new field.
       ;; Most commonly, this would be after entering a dir in file completion.
@@ -3087,7 +3088,11 @@ For use in the `select-mouse' frontend action.  `let'-bound.")
     (company-complete-selection)))
 
 (defun company-complete-selection ()
-  "Insert the selected candidate."
+  "Insert the selected candidate.
+
+Restart completion if a new field is entered. A field is indicated by
+`adjust-boundaries' as implemented in the backend. If both adjusted prefix
+and adjusted suffix are empty strings, that means a new field."
   (interactive)
   (when (and (company-manual-begin) company-selection)
     (let ((result (nth company-selection company-candidates)))

--- a/doc/company.texi
+++ b/doc/company.texi
@@ -332,6 +332,7 @@ Select the previous candidate
 @cindex complete
 @findex company-complete-selection
 Insert the selected candidate (@code{company-complete-selection}).
+Restart completion if a new field is entered.
 
 @item TAB
 @itemx <tab>


### PR DESCRIPTION
This sets up completion after RET to be restarted after entering a new "field".

Primarily an improvement for file name completion mostly (or other similar completion sources with "boundaries").

Hence the simplification in `company-files`.

This follows what Corfu does in `corfu-complete` but with a tweak which makes it both easier to implement here and closer to `completion--done`: exit-function is called either way after the completion is inserted (but with the symbol `exact` if the new field is entered).