### PR TITLE
Use company-complete-common-or-cycle in the default bindings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,13 +2,15 @@
 
 # Next
 
+* `TAB` binding changed to `company-complete-common-or-cycle`, and `backtab`
+  binding changed to `company-cycle-backward
+  (#[1499](https://github.com/company-mode/company-mode/pull/1499)).
 * Completion is restarted if it enters a new "field" at the end, as indicated by
   the `adjust-boundaries` backend action
   (#[1497](https://github.com/company-mode/company-mode/pull/1497)). This
   benefits file name (and directory) completion.  The user option
   `company-files-chop-trailing-slash` has been removed, and the
   `post-completion` handler in `company-files` has been removed as well.
-
 * Handle the case when the current c-a-p-f function changes mid-session
   (#[1494](https://github.com/company-mode/company-mode/pull/1494)).
 

--- a/company.el
+++ b/company.el
@@ -903,8 +903,9 @@ asynchronous call into synchronous.")
     (define-key keymap [up-mouse-3] 'ignore)
     (define-key keymap [return] 'company-complete-selection)
     (define-key keymap (kbd "RET") 'company-complete-selection)
-    (define-key keymap [tab] 'company-complete-common)
-    (define-key keymap (kbd "TAB") 'company-complete-common)
+    (define-key keymap [tab] 'company-complete-common-or-cycle)
+    (define-key keymap (kbd "TAB") 'company-complete-common-or-cycle)
+    (define-key keymap [backtab] 'company-cycle-backward)
     (define-key keymap (kbd "<f1>") 'company-show-doc-buffer)
     (define-key keymap (kbd "C-h") 'company-show-doc-buffer)
     (define-key keymap "\C-w" 'company-show-location)
@@ -3171,6 +3172,11 @@ With ARG, move by that many elements."
         (let ((company-selection-wrap-around t)
               (current-prefix-arg arg))
           (call-interactively 'company-select-next))))))
+
+(defun company-cycle-backward (&optional arg)
+  (interactive "p")
+  (let ((company-selection-wrap-around t))
+    (company-select-previous arg)))
 
 (defun company-complete-common-or-show-delayed-tooltip ()
   "Insert the common part of all candidates, or show a tooltip."

--- a/doc/company.texi
+++ b/doc/company.texi
@@ -338,9 +338,10 @@ Restart completion if a new field is entered.
 @itemx <tab>
 @kindex TAB
 @cindex common part
-@findex company-complete-common
-Insert the @emph{common part} of all completion candidates
-(@code{company-complete-common}).
+@findex company-complete-common-or-cycle
+Insert the @emph{common part} of all completion candidates or if it
+cannot be completed further, select the next candidate (with
+wraparound enabled) (@code{company-complete-common-or-cycle}).
 
 @item C-g
 @itemx <ESC ESC ESC>
@@ -391,18 +392,6 @@ illustrate how to assign key bindings to such commands.
 @lisp
 (with-eval-after-load 'company
   (define-key company-active-map (kbd "M-/") #'company-complete))
-@end lisp
-
-@lisp
-(with-eval-after-load 'company
-  (define-key company-active-map
-              (kbd "TAB")
-              #'company-complete-common-or-cycle)
-  (define-key company-active-map
-              (kbd "<backtab>")
-              (lambda ()
-                (interactive)
-                (company-complete-common-or-cycle -1))))
 @end lisp
 
 In the same manner, an additional key can be assigned to a command or

--- a/doc/company.texi
+++ b/doc/company.texi
@@ -2,8 +2,8 @@
 @c %**start of header
 @setfilename company.info
 @settitle Company User Manual
-@set VERSION 1.0.0
-@set UPDATED 21 September 2024
+@set VERSION 1.0.2
+@set UPDATED 5 November 2024
 @documentencoding UTF-8
 @documentlanguage en
 @paragraphindent asis
@@ -339,9 +339,11 @@ Restart completion if a new field is entered.
 @kindex TAB
 @cindex common part
 @findex company-complete-common-or-cycle
-Insert the @emph{common part} of all completion candidates or if it
-cannot be completed further, select the next candidate (with
-wraparound enabled) (@code{company-complete-common-or-cycle}).
+Insert the @emph{common part} of all completion candidates or --- if
+no @emph{common part} is present --- select the next candidate
+(@code{company-complete-common-or-cycle}).  In the latter case,
+wraparound is implicitly enabled
+(@pxref{company-selection-wrap-around}).
 
 @item C-g
 @itemx <ESC ESC ESC>
@@ -381,6 +383,9 @@ a more user-friendly output of the pre-defined key bindings, utilize
 @w{@kbd{M-x describe-keymap @key{RET} company-active-map}} or @w{@kbd{C-h
 f @key{RET} company-mode}}.}.
 
+@findex company-complete-common
+@findex company-indent-or-complete-common
+@findex company-complete
 Moreover, Company is bundled with a number of convenience commands
 that do not have default key bindings defined.  The following examples
 illustrate how to assign key bindings to such commands.
@@ -391,7 +396,8 @@ illustrate how to assign key bindings to such commands.
 
 @lisp
 (with-eval-after-load 'company
-  (define-key company-active-map (kbd "M-/") #'company-complete))
+  (define-key company-active-map (kbd "M-/") #'company-complete)
+  (define-key company-active-map (kbd "C-M-/") #'company-complete-common))
 @end lisp
 
 In the same manner, an additional key can be assigned to a command or
@@ -488,6 +494,7 @@ following example:
 @end lisp
 @end defopt
 
+@anchor{company-selection-wrap-around}
 @defopt company-selection-wrap-around
 Enable this option to loop (cycle) the candidates' selection: after
 selecting the last candidate on the list, a command to select the next


### PR DESCRIPTION
This has been a popular configuration for a number of years now. Making it a default for better OOtB experience.

There don't seem to be any significant drawbacks, and the upside is completion workflow that uses fewer keys (arrows or C-n/p are mostly not needed).

Notably, the `backtab` binding seems to work in the terminal as well here, though that probably depend on the terminal emulator and system libs versions.