### PR TITLE
Better document candidates post-processing

### DIFF
--- a/company.el
+++ b/company.el
@@ -537,9 +537,10 @@ even if the backend uses the asynchronous calling convention."
 (defcustom company-transformers nil
   "Functions to change the list of candidates received from backends.
 
-Each function gets called with the return value of the previous one.
+Each function is called with the return value of the previous one.
 The first one gets passed the list of candidates, already sorted and
-without duplicates."
+without duplicates (candidates with different annotations are considered to
+be distinct)."
   :type '(choice
           (const :tag "None" nil)
           (const :tag "Sort by occurrence" (company-sort-by-occurrence))

--- a/doc/company.texi
+++ b/doc/company.texi
@@ -1238,6 +1238,7 @@ backends simultaneously.  This can be achieved by configuring
 The most important part of this handling is the merge of the
 completion candidates from the grouped backends.
 
+@cindex :separate
 To keep the candidates organized in accordance with the grouped
 backends order, add the keyword @code{:separate} to the list of the
 grouped backends.  The following example illustrates this.
@@ -1251,6 +1252,7 @@ grouped backends.  The following example illustrates this.
 (add-hook 'text-mode-hook #'my-text-mode-hook)
 @end lisp
 
+@cindex :with
 Another keyword @code{:with} helps to make sure the results from
 major/minor mode agnostic backends (such as @emph{company-yasnippet},
 @emph{company-dabbrev-code}) are returned without preventing results

--- a/doc/company.texi
+++ b/doc/company.texi
@@ -2,8 +2,8 @@
 @c %**start of header
 @setfilename company.info
 @settitle Company User Manual
-@set VERSION 1.0.2
-@set UPDATED 5 November 2024
+@set VERSION 1.0.3-snapshot
+@set UPDATED 7 December 2024
 @documentencoding UTF-8
 @documentlanguage en
 @paragraphindent asis
@@ -1598,21 +1598,57 @@ system @uref{https://github.com/joaotavora/yasnippet, YASnippet}.
 @node Candidates Post-Processing
 @section Candidates Post-Processing
 
+@cindex post-processing
 @cindex sort
-@cindex duplicate
 @vindex company-transformers
-A list of completion candidates, supplied by a backend, can be
-additionally manipulated (reorganized, reduced, sorted, etc) before
-its output.  This is done by adding a processing function name to the
-user option @code{company-transformers} list, for example:
+A list of completion candidates supplied by backends can be
+manipulated before output: reorganized, reduced, sorted, etc.  To
+apply adjustments, add a processing function name to the user option
+@code{company-transformers} list.
+
+@cindex backends
+@cindex grouped backends
+@cindex :separate
+The transformer functions are called in a sequence, each with the
+return value of the previous one.  The first function receives a
+sorted list of distinct completion candidates.  Note that the default
+sorting behavior may be overridden by backends and influenced by the
+use of the keyword @code{:separate} in the grouped backends list
+(@pxref{Grouped Backends}).
+
+@cindex annotation
+@cindex duplicates
+Since Company does not treat candidates with differing annotations as
+duplicates, it may sometimes be desirable to condense completion lists
+containing such entries.  In the example below, post-processing begins
+with their removal.  Then, the weighted ordering of the candidates is
+performed.
 
 @lisp
+;; Set grouped backends.
+(setq company-backends '((company-capf company-dabbrev-code)))
+
+;; Apply post-processing.
 (setq company-transformers '(delete-consecutive-dups
                              company-sort-by-occurrence))
 @end lisp
 
-Company is bundled with several such transformer functions.  They are
-listed below.
+@cindex :separate
+@cindex duplicates
+If a grouped backend contains the keyword @code{:separate}, you can
+use the @code{delete-dups} function instead.
+
+@lisp
+;; Set grouped backends.
+(setq company-backends
+      '((:separate company-capf company-dabbrev-code)))
+
+;; Apply post-processing.
+(setq company-transformers '(delete-dups
+                             company-sort-by-occurrence))
+@end lisp
+
+Company is bundled with several transformer functions.
 
 @defun company-sort-by-occurrence
 Sorts candidates using @code{company-occurrence-weight-function}


### PR DESCRIPTION
Closes #1502 .

@mandarm, please let us know if the adjusted documentation looks sufficiently clear to you with this PR; and/or if you have any other suggestions.

@dgutov, it is [already documented](https://github.com/company-mode/company-mode/blob/0ae7c293112248a0c36377d6859a95d216ae5e96/company.el#L436) that Company keeps "duplicates" with different annotations. Still, it seems that adding this clarification also to the `company-transformers` docstring may be a good choice.

Also note, that I set the manual's version to 1.0.3-snapshot. [Previously,](https://github.com/company-mode/company-mode/pull/1228#issuecomment-997294550) we considered an approach of publishing only releases. And I am still doubtful whether pre-release documentation should be published.  Still, I guess it could be useful to have this PR's changes published. But that's unless you're planning on releasing the next version soon, or we are not fine to have a snapshot feature (such as #1499) description published. (The latter consideration is one of the reasons I haven't got to updating Tips & Tricks with #1499 changes.)

Thanks.
