### PR TITLE
Fix sorting of dabbrev-code backend for flex style

### DIFF
--- a/test/dabbrev-code-tests.el
+++ b/test/dabbrev-code-tests.el
@@ -1,0 +1,63 @@
+;;; dabbrev-code-tests.el --- company-mode tests  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2024  Free Software Foundation, Inc.
+
+;; Author: Denis Zubarev
+
+;; This file is part of GNU Emacs.
+
+;; GNU Emacs is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+
+(require 'company-tests)
+
+(ert-deftest company-dabbrev-code-with-flex-style-test ()
+  (with-temp-buffer
+    (insert "scheduled_job
+sa_enum
+self
+
+se")
+    (company-mode)
+    (let (company-frontends
+          company-transformers
+          (company-dabbrev-code-other-buffers nil)
+          (company-dabbrev-code-modes t)
+          (company-backends '(company-dabbrev-code))
+          (company-dabbrev-code-completion-styles '(flex)))
+      (ignore company-dabbrev-code-other-buffers
+              company-dabbrev-code-modes
+              company-dabbrev-code-completion-styles)
+
+      (company-manual-begin)
+      (should (equal '("self" "sa_enum" "scheduled_job") company-candidates)))))
+
+(ert-deftest company-dabbrev-code-with-basic-style-test ()
+  (with-temp-buffer
+    (insert "scheduled_job
+sa_enum
+self
+
+se")
+    (company-mode)
+    (let (company-frontends
+          company-transformers
+          (company-dabbrev-code-other-buffers nil)
+          (company-dabbrev-code-modes t)
+          (company-backends '(company-dabbrev-code))
+          (company-dabbrev-code-completion-styles '(basic)))
+      (ignore company-dabbrev-code-other-buffers
+              company-dabbrev-code-modes
+              company-dabbrev-code-completion-styles)
+      (company-manual-begin)
+      (should (equal '("self") company-candidates)))))


### PR DESCRIPTION
I've added tests, but here are steps for manual reproducing:
1. emacs -Q
2. Eval:
```elisp
(add-to-list 'load-path "/path/to/company-mode")
(require 'company)
```
3. M-x company-mode
4. Eval:
```elisp
(setq company-backends '(company-dabbrev-code))
(setq company-dabbrev-code-completion-styles '(flex))
```
5. Insert to the buffer
```
scheduled_job
sa_enum
self

se|
```
6. M-x company-complete
7. Displayed candidates:
```
sa_enum
scheduled_job
self
```
8. I expect that `self` would be at the first place.

I noticed that candidates were sorted in the `company--preprocess-candidates` in alphabetical order, because `company-dabbrev-code` always returned nil for `sorted` command.
Now `sorted` returns `t` if `company-dabbrev-code-completion-styles` implies that candidates will be sorted by the style.

After that fix the order of candidates became:
```
scheduled_job
sa_enum
self
```
So it seemed that candidates were returned in the order of their occurrence in the buffer.
It is really the case: the sorting function that is set in `completion--flex-adjust-metadata` never is used for sorting candidates. I don't know how to properly fix this, so I just added invocation of this function after candidates filtration.

GNU Emacs 30.0.93 (build 4, x86_64-pc-linux-gnu, GTK+ Version 3.24.43, cairo version 1.18.2) of 2024-12-26
Company version: 1.0.2