### PR TITLE
Add keywords and builtins for sh-mode

### DIFF
--- a/company-keywords.el
+++ b/company-keywords.el
@@ -377,6 +377,11 @@
      "new" "null" "object" "override" "package" "private" "protected"
      "return" "sealed" "super" "this" "throw" "trait" "true" "try" "type" "val"
      "var" "while" "with" "yield")
+    (sh-mode
+     "break" "case" "continue" "do" "done" "elif" "else" "esac" "eval"
+     "exec" "exit" "export" "false" "fi" "for" "function" "if" "in" "readonly"
+     "return" "set" "shift" "test" "then" "time" "times" "trap" "true" "unset"
+     "until" "while")
     (swift-mode
      "Protocol" "Self" "Type" "and" "as" "assignment" "associatedtype"
      "associativity" "available" "break" "case" "catch" "class" "column" "continue"


### PR DESCRIPTION
This commit will add keywords and names of shell builtins for `sh-mode`. This should fix #820.
