### PR TITLE
Add `async` and `await` as keywords for Python 3

### DIFF
--- a/company-keywords.el
+++ b/company-keywords.el
@@ -292,10 +292,10 @@
      "then" "type" "where")
     (python-mode
      ;; https://docs.python.org/3/reference/lexical_analysis.html#keywords
-     "False" "None" "True" "and" "as" "assert" "break" "class" "continue" "def"
-     "del" "elif" "else" "except" "exec" "finally" "for" "from" "global" "if"
-     "import" "in" "is" "lambda" "nonlocal" "not" "or" "pass" "print" "raise"
-     "return" "try" "while" "with" "yield")
+     "False" "None" "True" "and" "as" "assert" "async" "await" "break" "class"
+     "continue" "def" "del" "elif" "else" "except" "exec" "finally" "for" "from"
+     "global" "if" "import" "in" "is" "lambda" "nonlocal" "not" "or" "pass"
+     "print" "raise" "return" "try" "while" "with" "yield")
     (ruby-mode
      "BEGIN" "END" "alias" "and"  "begin" "break" "case" "class" "def" "defined?"
      "do" "else" "elsif"  "end" "ensure" "false" "for" "if" "in" "module"


### PR DESCRIPTION
In Python 3, `async` and `await` were added as keywords starting from version 3.7. Therefore, I have added these keywords to `company-keywords.el`.

---
Thanks to all the maintainers and contributors of company-mode.