### PR TITLE
Fix issue of "all" in 'company-dabbrev-other-buffers' for Emacs 31

### DIFF
--- a/company-dabbrev.el
+++ b/company-dabbrev.el
@@ -199,7 +199,7 @@ This variable affects both `company-dabbrev' and `company-dabbrev-code'."
                            company-dabbrev-time-limit
                            (pcase company-dabbrev-other-buffers
                              ('t (list major-mode))
-                             ; in emacs 31, 'all' is defined as a new function, make sure to let it before '(pred functionp)'.
+                             ;; `all' is a function starting with Emacs 31.
                              ('all 'all)
                              ((pred functionp) (funcall company-dabbrev-other-buffers (current-buffer)))
                              )))


### PR DESCRIPTION
In latest Emacs 31, "all" is added as a new function.

d1b3eb7eec64ffb9f2d89efda21660cab92bcf0c "Add any and all (bug#79611)"

** New functions 'any' and 'all'.
These return non-nil for lists where any and all elements, respectively, satisfy a given predicate.