### PR TITLE
Adding company-childframe frontend, for graphically rendered popups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Checkout Company
         uses: actions/checkout@v3
 
+      - name: Download dependency
+        run: make download
+
       - name: Run tests
         run: make test-batch
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 EMACS = emacs
+CURL=curl --silent
+POSFRAME_URL=https://raw.githubusercontent.com/tumashu/posframe/refs/heads/master/posframe.el
 
 ALL_TARGETS = help package clean test test-gui test-batch compile compile-warn
 
@@ -33,6 +35,9 @@ test-gui:
 test-batch:
 	${EMACS} -Q --batch -L . -l test/all.el \
 	--eval "(ert-run-tests-batch-and-exit '(not (or (tag interactive) (tag gui))))"
+
+download:
+	${CURL} ${POSFRAME_URL} > posframe.el
 
 compile:
 	${EMACS} -Q --batch -L . -f batch-byte-compile company.el company-*.el

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 # Next
 
+* New built-in frontend using "real graphical" widget for the popup
+  ([#1525](https://github.com/company-mode/company-mode/pull/1525)).
+  This also adds a hard dependency on the package `posframe`.
 * The minimum required version of Emacs is now 26.1.
 * `TAB` binding changed to `company-complete-common-or-cycle`, and `backtab`
   binding to `company-cycle-backward`

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -171,9 +171,11 @@ For COMMAND refer to `company-frontends'."
 
 (defun company-childframe-unless-just-one-frontend (command)
   "`company-childframe-frontend', but not shown for single candidates."
-  (unless (and (memq command '(post-command unhide))
-               (company--show-inline-p))
-    (company-childframe-frontend command)))
+  (if (company--show-inline-p)
+      (and (member command '(post-command hide))
+           (company-childframe-hide))
+    (and (memq command '(post-command unhide hide))
+         (company-childframe-frontend command))))
 
 (defun company-childframe-window-change ()
   "Hide posframe on window change."

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -158,7 +158,8 @@ Users of HiDPI screens might like to set it to 2."
 
 (defun company-childframe-hide ()
   "Hide company-childframe candidate menu."
-  (when (frame-live-p company-childframe--frame)
+  (when (and (frame-live-p company-childframe--frame)
+             (frame-visible-p company-childframe--frame))
     ;; PGTK/NS/W32 protocols know how to update the display atomically.
     (when (eq window-system 'x)
       ;; Seems to help avoid the final flicker - probably by keeping the parent's

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -129,7 +129,7 @@ Using current frame's font if it is nil."
            ;; :border-color "light salmon"
            ;; :border-color "light steel blue"
            ;; We'll probably want a separate face for it.
-           :border-color (face-attribute 'company-tooltip-scrollbar-thumb :background)
+           :border-color (face-attribute 'company-tooltip-scrollbar-track :background)
            :poshandler company-childframe-poshandler
            :poshandler-extra-info
            (list :company-margin margin

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -146,7 +146,12 @@ Users of HiDPI screens might like to set it to 2."
            company-childframe-show-params)
     (with-current-buffer buffer
       (use-local-map company-childframe-buffer-map)
-      (setq company-childframe--frame posframe--frame))))
+      (setq company-childframe--frame posframe--frame)
+      ;; FIXME: Does not honor remappings by minor modes in the parent buffer,
+      ;; e.g. the special behavior of C-d with parent-mode, etc.
+      (add-hook #'pre-command-hook
+                #'company-childframe--pre-command
+                nil t))))
 
 (defun company-childframe-hide ()
   "Hide company-childframe candidate menu."
@@ -178,22 +183,27 @@ For COMMAND refer to `company-frontends'."
 
 (defun company-childframe--select-mouse ()
   (let ((event-col-row (company--event-col-row company-mouse-event))
-        (event-window (posn-window (event-start company-mouse-event)))
-        (parent-frame (frame-parameter nil 'parent-frame))
-        (parent-buffer (frame-parameter nil 'posframe-parent-buffer)))
+        (event-window (posn-window (event-start company-mouse-event))))
     (cond ((and event-window
-                parent-frame
-                parent-buffer
                 (equal (buffer-name (window-buffer event-window))
                        company-childframe-buffer))
-           (select-frame parent-frame)
-           (select-window (get-buffer-window (cdr parent-buffer)))
            (company-set-selection (+ (cdr event-col-row)
                                      company-tooltip-offset
                                      (if (and (eq company-tooltip-offset-display 'lines)
                                               (not (zerop company-tooltip-offset)))
                                          -1 0)))
            t))))
+
+(defun company-childframe--pre-command ()
+  (let ((parent-frame (frame-parameter nil 'parent-frame))
+        (parent-buffer (cdr (frame-parameter nil 'posframe-parent-buffer))))
+    (when (and
+           (not (memq this-command
+                      '(company-childframe-wheel-up
+                        company-childframe-wheel-down)))
+           parent-frame parent-buffer)
+      (select-frame parent-frame)
+      (select-window (get-buffer-window parent-buffer)))))
 
 ;;;###autoload
 (defun company-childframe-unless-just-one-frontend (command)

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -114,11 +114,11 @@ Using current frame's font if it is nil."
       (use-local-map company-childframe-buffer-map))
     (apply #'posframe-show buffer
            :string contents
-           :min-height height
-           :min-width (+ company-tooltip-minimum-width
-                         (* 2 company-tooltip-margin))
-           :max-width (+ company-tooltip-maximum-width
-                         (* 2 company-tooltip-margin))
+           :height height
+           :width (if (<= company-candidates-length
+                          height)
+                      width
+                    (1- width))
            :font company-childframe-font
            :background-color (face-attribute 'company-tooltip :background)
            :lines-truncate t

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -56,14 +56,14 @@ Using current frame's font if it is nil."
     keymap)
   "Keymap for the child frame's popup/buffer.")
 
-(defun company-childframe-wheel-up (event)
+(defun company-childframe-wheel-up ()
   "Scroll up the displayed candidates."
-  (interactive "e")
+  (interactive)
   (company-childframe--wheel-scroll 3))
 
-(defun company-childframe-wheel-down (event)
+(defun company-childframe-wheel-down ()
   "Scroll up the displayed candidates."
-  (interactive "e")
+  (interactive)
   (company-childframe--wheel-scroll -3))
 
 (defun company-childframe--wheel-scroll (amount)

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -115,8 +115,9 @@ Using current frame's font if it is nil."
     (apply #'posframe-show buffer
            :string contents
            :height height
-           :width (if (<= company-candidates-length
-                          height)
+           :width (if (or (<= company-candidates-length
+                              height)
+                          (not (display-graphic-p)))
                       width
                     (1- width))
            :font company-childframe-font

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -191,7 +191,7 @@ For COMMAND refer to `company-frontends'."
   (if (company--show-inline-p)
       (and (member command '(post-command hide))
            (company-childframe-hide))
-    (and (memq command '(post-command unhide hide))
+    (and (memq command '(post-command unhide hide select-mouse))
          (company-childframe-frontend command))))
 
 (defun company-childframe-window-change ()

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -37,6 +37,12 @@
 Using current frame's font if it is nil."
   :type 'face)
 
+(defcustom company-childframe-border-width 1
+  "The width of the popup's border, in graphical frames.
+
+Users of HiDPI screens might like to set it to 2."
+  :type 'integer)
+
 (defvar company-childframe-buffer " *company-childframe-buffer*"
   "company-childframe's buffer which used by posframe.")
 
@@ -90,7 +96,9 @@ Using current frame's font if it is nil."
          ;; should be used to find the default width...
          (expected-margin-width (* (plist-get info :company-margin) (default-font-width)))
          (xy (posn-x-y posn)))
-    (setcar xy (- (car xy) expected-margin-width (if (display-graphic-p) 1 0)))
+    (setcar xy (- (car xy) expected-margin-width (if (display-graphic-p)
+                                                     company-childframe-border-width
+                                                   0)))
     (posframe-poshandler-point-bottom-left-corner (plist-put info :position posn))))
 
 (defun company-childframe-show ()
@@ -125,7 +133,7 @@ Using current frame's font if it is nil."
            :background-color (face-attribute 'company-tooltip :background)
            :lines-truncate t
            :override-parameters '((inhibit-double-buffering . t))
-           :border-width (and (display-graphic-p) 1)
+           :border-width (and (display-graphic-p) company-childframe-border-width)
            ;; :border-color "light salmon"
            ;; :border-color "light steel blue"
            ;; We'll probably want a separate face for it.

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -51,11 +51,30 @@ Using current frame's font if it is nil."
 (defvar company-childframe-buffer-map
   (let ((keymap (make-sparse-keymap)))
     (set-keymap-parent keymap company-active-map)
-    ;; FIXME: Implement mouse scrolling commands.
-    (define-key keymap [wheel-down] 'ignore)
-    (define-key keymap [wheel-up] 'ignore)
+    (define-key keymap [wheel-down] 'company-childframe-wheel-up)
+    (define-key keymap [wheel-up] 'company-childframe-wheel-down)
     keymap)
   "Keymap for the child frame's popup/buffer.")
+
+(defun company-childframe-wheel-up (event)
+  "Scroll up the displayed candidates."
+  (interactive "e")
+  (let ((company-mouse-event event)
+        (parent-frame (frame-parameter nil 'parent-frame))
+        (parent-buffer (frame-parameter nil 'posframe-parent-buffer)))
+    (select-frame parent-frame)
+    (select-window (get-buffer-window (cdr parent-buffer)))
+    (company-select-next 3)))
+
+(defun company-childframe-wheel-down (event)
+  "Scroll up the displayed candidates."
+  (interactive "e")
+  (let ((company-mouse-event event)
+        (parent-frame (frame-parameter nil 'parent-frame))
+        (parent-buffer (frame-parameter nil 'posframe-parent-buffer)))
+    (select-frame parent-frame)
+    (select-window (get-buffer-window (cdr parent-buffer)))
+    (company-select-previous 3)))
 
 (defvar company-childframe-poshandler
   #'company-childframe-show-at-prefix

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -90,7 +90,7 @@ Using current frame's font if it is nil."
          ;; should be used to find the default width...
          (expected-margin-width (* (plist-get info :company-margin) (default-font-width)))
          (xy (posn-x-y posn)))
-    (setcar xy (- (car xy) expected-margin-width))
+    (setcar xy (- (car xy) expected-margin-width (if (display-graphic-p) 1 0)))
     (posframe-poshandler-point-bottom-left-corner (plist-put info :position posn))))
 
 (defun company-childframe-show ()
@@ -123,6 +123,11 @@ Using current frame's font if it is nil."
            :background-color (face-attribute 'company-tooltip :background)
            :lines-truncate t
            :override-parameters '((inhibit-double-buffering . t))
+           :border-width (and (display-graphic-p) 1)
+           ;; :border-color "light salmon"
+           ;; :border-color "light steel blue"
+           ;; We'll probably want a separate face for it.
+           :border-color (face-attribute 'company-tooltip-scrollbar-thumb :background)
            :poshandler company-childframe-poshandler
            :poshandler-extra-info
            (list :company-margin margin

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -122,6 +122,7 @@ Using current frame's font if it is nil."
            :font company-childframe-font
            :background-color (face-attribute 'company-tooltip :background)
            :lines-truncate t
+           :override-parameters '((inhibit-double-buffering . t))
            :poshandler company-childframe-poshandler
            :poshandler-extra-info
            (list :company-margin margin

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -20,8 +20,8 @@
 ;;
 ;; Tooltip completion menu frontend for Company that uses a child frame.
 ;;
-;; A lot of the code here originates from the package `company-posframe',
-;; credits to Clément Pit-Claudel, Feng Shu and others.
+;; A lot of the code here was imported from the package `company-posframe',
+;; credit to Clément Pit-Claudel, Feng Shu and others.
 
 ;;; Code:
 

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -1,0 +1,138 @@
+;;; company-childframe.el --- Graphical popup frontend for Company  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2026  Free Software Foundation, Inc.
+
+;; GNU Emacs is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
+
+
+;;; Commentary:
+;;
+;; Tooltip completion menu frontend for Company that uses a child frame.
+;;
+;; A lot of the code here originates from the package `company-posframe',
+;; credits to Clément Pit-Claudel, Feng Shu and others.
+
+;;; Code:
+
+(require 'company)
+(require 'posframe)
+
+(defgroup company-childframe nil
+  "Group group group"
+  :group 'company)
+
+(defcustom company-childframe-font nil
+  "The font used by company-childframe's frame.
+Using current frame's font if it is nil."
+  :type 'face)
+
+(defvar company-childframe-buffer " *company-childframe-buffer*"
+  "company-childframe's buffer which used by posframe.")
+
+(defvar company-childframe--frame nil)
+
+(defvar company-childframe-show-params nil
+  "List of extra parameters passed to `posframe-show' in
+  `company-childframe-show'.")
+
+(defvar company-childframe-last-status nil)
+
+(defvar company-childframe-poshandler
+  #'company-childframe-show-at-prefix
+  "Poshandler for the completion dialog.")
+
+(defun company-childframe-show-at-prefix (info)
+  "Poshandler showing `company-childframe' at `company-prefix'."
+  (let* ((parent-window (plist-get info :parent-window))
+         (point (with-current-buffer (window-buffer parent-window)
+                  (- (plist-get info :position)
+                     (plist-get info :company-prefix-length))))
+         (posn (posn-at-point point parent-window))
+         ;; TODO: Strictly speaking, if company-childframe-font is not nil, that
+         ;; should be used to find the default width...
+         (expected-margin-width (* (plist-get info :company-margin) (default-font-width)))
+         (xy (posn-x-y posn)))
+    (setcar xy (- (car xy) expected-margin-width))
+    (posframe-poshandler-point-bottom-left-corner (plist-put info :position posn))))
+
+(defun company-childframe-show ()
+  "Show company-childframe candidate menu."
+  (let* ((height (min company-tooltip-limit company-candidates-length))
+         (company-lines (company--create-lines company-selection height))
+         (margin (car company-lines))
+         (lines (cdr company-lines))
+         (width (max (min (length (car lines))
+                          company-tooltip-maximum-width)
+                     company-tooltip-minimum-width))
+         (contents (mapconcat #'identity lines "\n"))
+         (buffer (get-buffer-create company-childframe-buffer)))
+    ;; FIXME: Do not support mouse at the moment, so remove mouse-face
+    (setq contents (copy-sequence contents))
+    (remove-text-properties 0 (length contents) '(mouse-face nil) contents)
+    (apply #'posframe-show buffer
+           :string contents
+           :min-height height
+           :min-width (+ company-tooltip-minimum-width
+                         (* 2 company-tooltip-margin))
+           :max-width (+ company-tooltip-maximum-width
+                         (* 2 company-tooltip-margin))
+           :font company-childframe-font
+           :background-color (face-attribute 'company-tooltip :background)
+           :lines-truncate t
+           :poshandler company-childframe-poshandler
+           :poshandler-extra-info
+           (list :company-margin margin
+                 :company-prefix-length (length company-prefix))
+           company-childframe-show-params)))
+
+(defun company-childframe-hide ()
+  "Hide company-childframe candidate menu."
+  (posframe-hide company-childframe-buffer))
+
+(defun company-childframe-frontend (command)
+  "`company-mode' frontend using childframe.
+For COMMAND refer to `company-frontends'."
+  (when (not (posframe-workable-p))
+    (user-error "Child frames no supported"))
+  (setq company-childframe-last-status
+        (list (selected-window)
+              (current-buffer)))
+  (cl-case command
+    (pre-command)
+    (hide
+     (company-childframe-hide))
+    (post-command
+     (company-childframe-show))))
+
+(defun company-childframe-unless-just-one-frontend (command)
+  "`company-childframe-frontend', but not shown for single candidates."
+  (unless (and (memq command '(post-command unhide))
+               (company--show-inline-p))
+    (company-childframe-frontend command)))
+
+(defun company-childframe-window-change ()
+  "Hide posframe on window change."
+  (when (posframe-workable-p)
+    (unless (or (member (buffer-name)
+                        (list company-childframe-buffer))
+                (equal company-childframe-last-status
+                       (list (selected-window)
+                             (current-buffer))))
+      (company-childframe-hide))))
+
+(add-hook 'window-configuration-change-hook
+          #'company-childframe-window-change)
+
+(provide 'company-childframe)
+;;; company-childframe.el ends here

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -153,8 +153,7 @@ For COMMAND refer to `company-frontends'."
 (defun company-childframe-window-change ()
   "Hide posframe on window change."
   (when (posframe-workable-p)
-    (unless (or (member (buffer-name)
-                        (list company-childframe-buffer))
+    (unless (or (equal (buffer-name) company-childframe-buffer)
                 (equal company-childframe-last-status
                        (list (selected-window)
                              (current-buffer))))

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -97,7 +97,6 @@ Using current frame's font if it is nil."
   "Show company-childframe candidate menu."
   (let* ((x-wait-for-event-timeout nil)
          ;; Above: real effect (less flicker), below: just seem sensible.
-         (inhibit-redisplay t)
          (before-make-frame-hook)
          (after-make-frame-functions)
          (x-fast-protocol-requests t)

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -158,13 +158,13 @@ Users of HiDPI screens might like to set it to 2."
 
 (defun company-childframe-hide ()
   "Hide company-childframe candidate menu."
-  ;; PGTK/NS/W32 protocols know how to update the display atomically.
-  (when (and (eq window-system 'x)
-             (frame-live-p company-childframe--frame))
-    ;; Seems to help avoid the final flicker - probably by keeping the parent's
-    ;; display matrix up to date (so it can repaint on Expose immediately).
-    (redisplay))
-  (make-frame-invisible company-childframe--frame))
+  (when (frame-live-p company-childframe--frame)
+    ;; PGTK/NS/W32 protocols know how to update the display atomically.
+    (when (eq window-system 'x)
+      ;; Seems to help avoid the final flicker - probably by keeping the parent's
+      ;; display matrix up to date (so it can repaint on Expose immediately).
+      (redisplay))
+    (make-frame-invisible company-childframe--frame)))
 
 ;;;###autoload
 (defun company-childframe-frontend (command)

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -177,6 +177,7 @@ For COMMAND refer to `company-frontends'."
     (pre-command
      (when (not (posframe-workable-p))
        (user-error "Child frames not supported")))
+    (show (setq company--tooltip-current-width 0))
     (hide
      (company-childframe-hide))
     (post-command
@@ -214,7 +215,7 @@ For COMMAND refer to `company-frontends'."
   (if (company--show-inline-p)
       (and (member command '(post-command hide))
            (company-childframe-hide))
-    (and (memq command '(post-command unhide hide select-mouse))
+    (and (memq command '(post-command show unhide hide select-mouse))
          (company-childframe-frontend command))))
 
 (defun company-childframe-window-change ()

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -116,6 +116,12 @@ Users of HiDPI screens might like to set it to 2."
                      company-tooltip-minimum-width))
          (contents (mapconcat #'identity lines "\n"))
          (buffer (get-buffer-create company-childframe-buffer)))
+    (when (and (eq (frame-live-p company-childframe--frame) 'x)
+               (not (eq (car (frame-list)) company-childframe--frame)))
+      ;; Make sure it's the first in the list, to avoid premature sync when some
+      ;; other frame is redisplayed first.  Again, non-atomic updated on X11.
+      ;; https://debbugs.gnu.org/80662#185
+      (delete-frame company-childframe--frame))
     (apply #'posframe-show buffer
            :string contents
            :height height

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -138,6 +138,7 @@ Using current frame's font if it is nil."
   "Hide company-childframe candidate menu."
   (posframe-hide company-childframe-buffer))
 
+;;;###autoload
 (defun company-childframe-frontend (command)
   "`company-mode' frontend using childframe.
 For COMMAND refer to `company-frontends'."
@@ -174,6 +175,7 @@ For COMMAND refer to `company-frontends'."
                                          -1 0)))
            t))))
 
+;;;###autoload
 (defun company-childframe-unless-just-one-frontend (command)
   "`company-childframe-frontend', but not shown for single candidates."
   (if (company--show-inline-p)

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -116,8 +116,6 @@ Users of HiDPI screens might like to set it to 2."
                      company-tooltip-minimum-width))
          (contents (mapconcat #'identity lines "\n"))
          (buffer (get-buffer-create company-childframe-buffer)))
-    (with-current-buffer buffer
-      (use-local-map company-childframe-buffer-map))
     (apply #'posframe-show buffer
            :string contents
            :height height
@@ -139,11 +137,20 @@ Users of HiDPI screens might like to set it to 2."
            :poshandler-extra-info
            (list :company-margin margin
                  :company-prefix-length (length company-prefix))
-           company-childframe-show-params)))
+           company-childframe-show-params)
+    (with-current-buffer buffer
+      (use-local-map company-childframe-buffer-map)
+      (setq company-childframe--frame posframe--frame))))
 
 (defun company-childframe-hide ()
   "Hide company-childframe candidate menu."
-  (posframe-hide company-childframe-buffer))
+  ;; PGTK/NS/W32 protocols know how to update the display atomically.
+  (when (and (eq window-system 'x)
+             (frame-live-p company-childframe--frame))
+    ;; Seems to help avoid the final flicker - probably by keeping the parent's
+    ;; display matrix up to date (so it can repaint on Expose immediately).
+    (redisplay))
+  (make-frame-invisible company-childframe--frame))
 
 ;;;###autoload
 (defun company-childframe-frontend (command)

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -152,7 +152,7 @@ Users of HiDPI screens might like to set it to 2."
       (setq company-childframe--frame posframe--frame)
       ;; FIXME: Does not honor remappings by minor modes in the parent buffer,
       ;; e.g. the special behavior of C-d with parent-mode, etc.
-      (add-hook #'pre-command-hook
+      (add-hook 'pre-command-hook
                 #'company-childframe--pre-command
                 nil t))))
 

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -160,7 +160,7 @@ Users of HiDPI screens might like to set it to 2."
   "Hide company-childframe candidate menu."
   (when (and (frame-live-p company-childframe--frame)
              (frame-visible-p company-childframe--frame))
-    ;; PGTK/NS/W32 protocols know how to update the display atomically.
+    ;; PGTK/NS/W32 protocols can update the display atomically.
     (when (eq window-system 'x)
       ;; Seems to help avoid the final flicker - probably by keeping the parent's
       ;; display matrix up to date (so it can repaint on Expose immediately).

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -59,22 +59,21 @@ Using current frame's font if it is nil."
 (defun company-childframe-wheel-up (event)
   "Scroll up the displayed candidates."
   (interactive "e")
-  (let ((company-mouse-event event)
-        (parent-frame (frame-parameter nil 'parent-frame))
-        (parent-buffer (frame-parameter nil 'posframe-parent-buffer)))
-    (select-frame parent-frame)
-    (select-window (get-buffer-window (cdr parent-buffer)))
-    (company-select-next 3)))
+  (company-childframe--wheel-scroll 3))
 
 (defun company-childframe-wheel-down (event)
   "Scroll up the displayed candidates."
   (interactive "e")
-  (let ((company-mouse-event event)
-        (parent-frame (frame-parameter nil 'parent-frame))
+  (company-childframe--wheel-scroll -3))
+
+(defun company-childframe--wheel-scroll (amount)
+  (let ((parent-frame (frame-parameter nil 'parent-frame))
         (parent-buffer (frame-parameter nil 'posframe-parent-buffer)))
-    (select-frame parent-frame)
-    (select-window (get-buffer-window (cdr parent-buffer)))
-    (company-select-previous 3)))
+    (when (and parent-frame
+               parent-buffer)
+      (select-frame parent-frame)
+      (select-window (get-buffer-window (cdr parent-buffer)))
+      (company-select-next amount))))
 
 (defvar company-childframe-poshandler
   #'company-childframe-show-at-prefix

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -95,6 +95,7 @@ Using current frame's font if it is nil."
 
 (defun company-childframe-show ()
   "Show company-childframe candidate menu."
+  (defvar x-wait-for-event-timeout)
   (defvar x-fast-protocol-requests)
   (let* ((x-wait-for-event-timeout nil)
          ;; Above: real effect (less flicker), below: just seem sensible.

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -48,6 +48,15 @@ Using current frame's font if it is nil."
 
 (defvar company-childframe-last-status nil)
 
+(defvar company-childframe-buffer-map
+  (let ((keymap (make-sparse-keymap)))
+    (set-keymap-parent keymap company-active-map)
+    ;; FIXME: Implement mouse scrolling commands.
+    (define-key keymap [wheel-down] 'ignore)
+    (define-key keymap [wheel-up] 'ignore)
+    keymap)
+  "Keymap for the child frame's popup/buffer.")
+
 (defvar company-childframe-poshandler
   #'company-childframe-show-at-prefix
   "Poshandler for the completion dialog.")
@@ -77,9 +86,8 @@ Using current frame's font if it is nil."
                      company-tooltip-minimum-width))
          (contents (mapconcat #'identity lines "\n"))
          (buffer (get-buffer-create company-childframe-buffer)))
-    ;; FIXME: Do not support mouse at the moment, so remove mouse-face
-    (setq contents (copy-sequence contents))
-    (remove-text-properties 0 (length contents) '(mouse-face nil) contents)
+    (with-current-buffer buffer
+      (use-local-map company-childframe-buffer-map))
     (apply #'posframe-show buffer
            :string contents
            :min-height height
@@ -103,17 +111,38 @@ Using current frame's font if it is nil."
 (defun company-childframe-frontend (command)
   "`company-mode' frontend using childframe.
 For COMMAND refer to `company-frontends'."
-  (when (not (posframe-workable-p))
-    (user-error "Child frames no supported"))
   (setq company-childframe-last-status
         (list (selected-window)
               (current-buffer)))
   (cl-case command
-    (pre-command)
+    (pre-command
+     (when (not (posframe-workable-p))
+       (user-error "Child frames not supported")))
     (hide
      (company-childframe-hide))
     (post-command
-     (company-childframe-show))))
+     (company-childframe-show))
+    (select-mouse
+     (company-childframe--select-mouse))))
+
+(defun company-childframe--select-mouse ()
+  (let ((event-col-row (company--event-col-row company-mouse-event))
+        (event-window (posn-window (event-start company-mouse-event)))
+        (parent-frame (frame-parameter nil 'parent-frame))
+        (parent-buffer (frame-parameter nil 'posframe-parent-buffer)))
+    (cond ((and event-window
+                parent-frame
+                parent-buffer
+                (equal (buffer-name (window-buffer event-window))
+                       company-childframe-buffer))
+           (select-frame parent-frame)
+           (select-window (get-buffer-window (cdr parent-buffer)))
+           (company-set-selection (+ (cdr event-col-row)
+                                     company-tooltip-offset
+                                     (if (and (eq company-tooltip-offset-display 'lines)
+                                              (not (zerop company-tooltip-offset)))
+                                         -1 0)))
+           t))))
 
 (defun company-childframe-unless-just-one-frontend (command)
   "`company-childframe-frontend', but not shown for single candidates."

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -77,7 +77,13 @@ Using current frame's font if it is nil."
 
 (defun company-childframe-show ()
   "Show company-childframe candidate menu."
-  (let* ((height (min company-tooltip-limit company-candidates-length))
+  (let* ((x-wait-for-event-timeout nil)
+         ;; Above: real effect (less flicker), below: just seem sensible.
+         (inhibit-redisplay t)
+         (before-make-frame-hook)
+         (after-make-frame-functions)
+         (x-fast-protocol-requests t)
+         (height (min company-tooltip-limit company-candidates-length))
          (company-lines (company--create-lines company-selection height))
          (margin (car company-lines))
          (lines (cdr company-lines))

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -103,8 +103,11 @@ Users of HiDPI screens might like to set it to 2."
 
 (defun company-childframe-show ()
   "Show company-childframe candidate menu."
+  (defvar x-wait-for-event-timeout)
   (defvar x-fast-protocol-requests)
-  (let* ((before-make-frame-hook)
+  (let* (;; Should be unnecessary in Emacs 31+, debbugs#80662.
+         (x-wait-for-event-timeout nil)
+         (before-make-frame-hook)
          (after-make-frame-functions)
          (x-fast-protocol-requests t)
          (height (min company-tooltip-limit company-candidates-length))

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -103,11 +103,8 @@ Users of HiDPI screens might like to set it to 2."
 
 (defun company-childframe-show ()
   "Show company-childframe candidate menu."
-  (defvar x-wait-for-event-timeout)
   (defvar x-fast-protocol-requests)
-  (let* ((x-wait-for-event-timeout nil)
-         ;; Above: real effect (less flicker), below: just seem sensible.
-         (before-make-frame-hook)
+  (let* ((before-make-frame-hook)
          (after-make-frame-functions)
          (x-fast-protocol-requests t)
          (height (min company-tooltip-limit company-candidates-length))

--- a/company-childframe.el
+++ b/company-childframe.el
@@ -95,6 +95,7 @@ Using current frame's font if it is nil."
 
 (defun company-childframe-show ()
   "Show company-childframe candidate menu."
+  (defvar x-fast-protocol-requests)
   (let* ((x-wait-for-event-timeout nil)
          ;; Above: real effect (less flicker), below: just seem sensible.
          (before-make-frame-hook)

--- a/company.el
+++ b/company.el
@@ -191,21 +191,22 @@
 
 (defun company-frontends-set (variable value)
   ;; Uniquify.
-  (let ((value (delete-dups (copy-sequence value))))
-    (and (or (and (memq 'company-pseudo-tooltip-unless-just-one-frontend value)
-                  (memq 'company-pseudo-tooltip-frontend value))
-             (and (memq 'company-pseudo-tooltip-unless-just-one-frontend-with-delay value)
-                  (memq 'company-pseudo-tooltip-frontend value))
-             (and (memq 'company-pseudo-tooltip-unless-just-one-frontend-with-delay value)
-                  (memq 'company-pseudo-tooltip-unless-just-one-frontend value)))
-         (user-error "Pseudo tooltip frontend cannot be used more than once"))
-    (and (or (and (memq 'company-preview-if-just-one-frontend value)
-                  (memq 'company-preview-frontend value))
-             (and (memq 'company-preview-if-just-one-frontend value)
-                  (memq 'company-preview-common-frontend value))
-             (and (memq 'company-preview-frontend value)
-                  (memq 'company-preview-common-frontend value))
-             )
+  (let ((value (delete-dups (copy-sequence value)))
+        (tooltip-frontends
+         '(company-pseudo-tooltip-frontend
+           company-pseudo-tooltip-unless-just-one-frontend
+           company-pseudo-tooltip-unless-just-one-frontend-with-delay
+           company-childframe-frontend
+           company-childframe-unless-just-one-frontend))
+        (preview-frontends
+         '(company-preview-if-just-one-frontend
+           company-preview-common-frontend
+           company-preview-frontend)))
+    (and (> (cl-count-if (lambda (el) (member el tooltip-frontends)) value)
+            1)
+         (user-error "Any tooltip frontend can be used only once"))
+    (and (> (cl-count-if (lambda (el) (member el preview-frontends)) value)
+            1)
          (user-error "Preview frontend cannot be used twice"))
     (and (memq 'company-echo value)
          (memq 'company-echo-metadata-frontend value)
@@ -246,16 +247,20 @@ The visualized data is stored in `company-prefix', `company-candidates',
   :type '(repeat (choice (const :tag "echo" company-echo-frontend)
                          (const :tag "echo, strip common"
                                 company-echo-strip-common-frontend)
-                         (const :tag "show echo meta-data in echo"
+                         (const :tag "show completion's meta-data in echo"
                                 company-echo-metadata-frontend)
-                         (const :tag "pseudo tooltip"
+                         (const :tag "graphical tooltip"
+                                company-childframe-frontend)
+                         (const :tag "graphical tooltip, multiple completions only"
+                                company-childframe-unless-just-one-frontend)
+                         (const :tag "overlays based tooltip"
                                 company-pseudo-tooltip-frontend)
-                         (const :tag "pseudo tooltip, multiple only"
+                         (const :tag "overlays based tooltip, multiple completions only"
                                 company-pseudo-tooltip-unless-just-one-frontend)
-                         (const :tag "pseudo tooltip, multiple only, delayed"
+                         (const :tag "overlays based tooltip, multiple completions only, delayed"
                                 company-pseudo-tooltip-unless-just-one-frontend-with-delay)
                          (const :tag "preview" company-preview-frontend)
-                         (const :tag "preview, unique only"
+                         (const :tag "preview, unique completion only"
                                 company-preview-if-just-one-frontend)
                          (const :tag "preview, common"
                                 company-preview-common-frontend)

--- a/company.el
+++ b/company.el
@@ -1,13 +1,13 @@
 ;;; company.el --- Modular text completion framework  -*- lexical-binding: t -*-
 
-;; Copyright (C) 2009-2025  Free Software Foundation, Inc.
+;; Copyright (C) 2009-2026  Free Software Foundation, Inc.
 
 ;; Author: Nikolaj Schumacher
 ;; Maintainer: Dmitry Gutov <dmitry@gutov.dev>
 ;; URL: http://company-mode.github.io/
 ;; Version: 1.0.2
 ;; Keywords: abbrev, convenience, matching
-;; Package-Requires: ((emacs "26.1"))
+;; Package-Requires: ((emacs "26.1") (posframe "1.5.1")
 
 ;; This file is part of GNU Emacs.
 


### PR DESCRIPTION
Most of the code has been imported from  company-childframe, so credit is due to its authors: Clément Pit-Claudel, Feng Shu and others. In part this was motivated by some parts of that package which don't have "clean" copyright status from the FSF's point of view, so here we have removed a bunch of features:

* The list of backends or metadata in the popup.
* The posframe-quickhelp feature.

Neither is a decision set in stone - we can bring those later (probably with a clean rewrite, if only for copyright assignment purposes). Feature requests could move motivate it too.

### Improvements

* Better integration - no advices or overriding functions.
* Mouse interactions with the popup work (selecting, changing selection, scrolling).
* [Linux/X11] Less flickering when the popup is resized, moved or hidden.
* Border around the popup.

<img width="269" height="230" alt="image" src="https://github.com/user-attachments/assets/de0032a5-a30c-44a3-9def-24188382a1cf" />

### Things that stayed the same

* "Real" popup implementation, displayed over variable font text, images, inner window borders.
* Works in TTY too.

### How to try it

```el
(setq company-frontends '(company-childframe-unless-just-one-frontend
                          company-preview-if-just-one-frontend
                          company-echo-metadata-frontend))
```

### Tips

[*Linux/X11 only*] Changes upstream that improve how smoothly the popup is shown/resized/hidden:

* https://github.com/tumashu/posframe/pull/151, https://github.com/tumashu/posframe/pull/156.
* Emacs core: [debbugs#80369](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=80369) (fixed), [debbugs#80662](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=80662) (**pending**).

_If your Emacs does not include the fix_ (e.g. the current release 30.1), and you're using GNU/Linux, try the _GTK3_, _PGTK_, or the _no-toolkit_ build. Each has some issues, but PGTK is best WRT to flickering (its absence).

The macOS port doesn't seem to be affected. [Untested, but W32/Haiku/Android should be same.]

Also to reduce the amount of popup resizing, try `(setq company-tooltip-width-grow-only t)`.