### PR TITLE
Fix company-dabbrev crash on Emacs 31: reorder pcase arms

### DIFF
--- a/company-dabbrev.el
+++ b/company-dabbrev.el
@@ -199,8 +199,8 @@ This variable affects both `company-dabbrev' and `company-dabbrev-code'."
                            company-dabbrev-time-limit
                            (pcase company-dabbrev-other-buffers
                              (`t (list major-mode))
-                             ((pred functionp) (funcall company-dabbrev-other-buffers (current-buffer)))
-                             (`all `all))))
+                             (`all `all)
+                             ((pred functionp) (funcall company-dabbrev-other-buffers (current-buffer))))))
 
 ;;;###autoload
 (defun company-dabbrev (command &optional arg &rest _ignored)


### PR DESCRIPTION
Emacs 31 adds a new builtin `all` function with signature `(all PRED LIST)`. This makes `(functionp 'all)` return `t`, so the `(pred functionp)` pcase arm in `company-dabbrev--fetch` now matches the symbol `'all` before the literal `` `all `` arm can. The result is `(funcall 'all buffer)` → `wrong-number-of-arguments`.

Fix: check the literal `` `all `` before `(pred functionp)`.

Fixes #1530