### PR TITLE
Clarify no Invariant Section of GFDL for docs

### DIFF
--- a/doc/company.texi
+++ b/doc/company.texi
@@ -18,7 +18,8 @@ Copyright @copyright{} 2021-2024  Free Software Foundation, Inc.
 @quotation
 Permission is granted to copy, distribute and/or modify this document
 under the terms of the GNU Free Documentation License, Version 1.3 or
-any later version published by the Free Software Foundation.
+any later version published by the Free Software Foundation, with no
+Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
 @end quotation
 @end copying
 


### PR DESCRIPTION
- Add text of `no Invariant Section, no Front-Cover Texts, and no Back-Cover Texts' to GFDL license notice for `doc/company.texi'.

- This makes the license conforming to the Debian Free Software Guidelines.

- More info: https://wiki.debian.org/DFSGLicenses#GNU_Free_Documentation_License_.28GFDL.29