### PR TITLE
Enable company-childframe by default where we can

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 # Next
 
+* `company-tooltip-minimum-width` has a new value: 15.
+* `company-tooltip-maximum-width`: same, 100.
+* `company-tooltip-width-grow-only` learned how to grow only up to particular
+  size (implemented in `company--create-lines`). The default value is 50.
+* `company-childframe` gets enabled by default on NS/Mac/W32/PGTK systems, and
+  on all others (notably X11 builds) when Emacs is at least 31
+  ([#1542](https://github.com/company-mode/company-mode/pull/1542)).
 * Default key bindings have been changed, moving `company-show-doc-buffer` and
   `company-show-location` to `M-h` and `M-g` (from `C-h`/`<f1>` and `C-w`)
   ([#1537](https://github.com/company-mode/company-mode/issues/1537)). The

--- a/company.el
+++ b/company.el
@@ -217,7 +217,11 @@
         (setq value (append (delq f value) (list f)))))
     (set variable value)))
 
-(defcustom company-frontends '(company-pseudo-tooltip-unless-just-one-frontend
+(defcustom company-frontends `(,@(list
+                                  (if (or (memq window-system '(ns mac w32 pgtk))
+                                          (< 30 emacs-major-version))
+                                      'company-childframe-unless-just-one-frontend
+                                    'company-pseudo-tooltip-unless-just-one-frontend))
                                company-preview-if-just-one-frontend
                                company-echo-metadata-frontend)
   "The list of active frontends (visualizations).
@@ -243,6 +247,7 @@ for technical reasons.
 The visualized data is stored in `company-prefix', `company-candidates',
 `company-common', `company-selection', `company-point' and
 `company-search-string'."
+  :package-version '(company . "1.1.0")
   :set 'company-frontends-set
   :type '(repeat (choice (const :tag "echo" company-echo-frontend)
                          (const :tag "echo, strip common"
@@ -276,22 +281,22 @@ When that many lines are not available between point and the bottom of the
 window, display the tooltip above point."
   :type 'integer)
 
-(defcustom company-tooltip-minimum-width 0
+(defcustom company-tooltip-minimum-width 15
   "The minimum width of the tooltip's inner area.
 This doesn't include the margins and the scroll bar."
   :type 'integer
-  :package-version '(company . "0.8.0"))
+  :package-version '(company . "1.1.0"))
 
-(defcustom company-tooltip-maximum-width most-positive-fixnum
+(defcustom company-tooltip-maximum-width 100
   "The maximum width of the tooltip's inner area.
 This doesn't include the margins and the scroll bar."
   :type 'integer
-  :package-version '(company . "0.9.5"))
+  :package-version '(company . "1.1.0"))
 
-(defcustom company-tooltip-width-grow-only nil
+(defcustom company-tooltip-width-grow-only 50
   "When non-nil, the tooltip width is not allowed to decrease."
   :type 'boolean
-  :package-version '(company . "0.10.0"))
+  :package-version '(company . "1.1.0"))
 
 (defcustom company-tooltip-margin 1
   "Width of margin columns to show around the toolip."
@@ -4217,7 +4222,13 @@ but adjust the expected values appropriately."
                             width))))
 
     (when company-tooltip-width-grow-only
-      (setq width (max company--tooltip-current-width width))
+      (setq width (max
+                   (min
+                    (if (numberp company-tooltip-width-grow-only)
+                        company-tooltip-width-grow-only
+                      most-positive-fixnum)
+                    company--tooltip-current-width)
+                   width))
       (setq company--tooltip-current-width width))
 
     (let ((items (nreverse items))

--- a/test/capf-tests.el
+++ b/test/capf-tests.el
@@ -25,6 +25,7 @@
 (require 'company-tests)
 (require 'company-capf)
 (require 'cl-lib)
+(require 'company-childframe)
 
 (defmacro company-capf-with-buffer (contents &rest body)
   (declare (indent 0) (debug (sexp &rest form)))

--- a/test/frontends-tests.el
+++ b/test/frontends-tests.el
@@ -48,7 +48,8 @@
     (let ((col (company--column))
           (company-candidates-length 2)
           (company-candidates '("123" "45"))
-          (company-backend 'ignore))
+          (company-backend 'ignore)
+          (company-tooltip-minimum-width 0))
       (company-pseudo-tooltip-show (company--row) col 0)
       (let ((ov company-pseudo-tooltip-overlay))
         ;; With margins.
@@ -85,7 +86,8 @@
           (company-candidates '("123" "45" "67" "89" "1011"))
           (company-backend 'ignore)
           (company-tooltip-limit 4)
-          (company-tooltip-offset-display 'scrollbar))
+          (company-tooltip-offset-display 'scrollbar)
+          (company-tooltip-minimum-width 0))
       (company-pseudo-tooltip-show (company--row)
                                    (company--column)
                                    0)
@@ -122,7 +124,8 @@
                                (when (eq action 'annotation)
                                  (cdr (assoc arg '(("123" . "(4)")))))))
             (company-candidates '("123" "45"))
-            company-tooltip-align-annotations)
+            company-tooltip-align-annotations
+            (company-tooltip-minimum-width 0))
         (company-pseudo-tooltip-show-at-point (point) 0)
         (let ((ov company-pseudo-tooltip-overlay))
           ;; With margins.
@@ -143,7 +146,8 @@
                                  (cdr (assoc arg '(("123" . "(4)")
                                                    ("67" . "(891011)")))))))
             (company-candidates '("123" "45" "67"))
-            (company-tooltip-annotation-padding 2))
+            (company-tooltip-annotation-padding 2)
+            (company-tooltip-minimum-width 0))
         (company-pseudo-tooltip-show-at-point (point) 0)
         (let ((ov company-pseudo-tooltip-overlay))
           ;; With margins.
@@ -164,7 +168,8 @@
                                  (cdr (assoc arg '(("123" . "(4)")
                                                    ("67" . "(891011)")))))))
             (company-candidates '("123" "45" "67"))
-            (company-tooltip-align-annotations t))
+            (company-tooltip-align-annotations t)
+            (company-tooltip-minimum-width 0))
         (company-pseudo-tooltip-show-at-point (point) 0)
         (let ((ov company-pseudo-tooltip-overlay))
           ;; With margins.
@@ -186,7 +191,8 @@
                                                    ("67" . "(891011)")))))))
             (company-candidates '("123" "45" "67"))
             (company-tooltip-align-annotations t)
-            (company-tooltip-annotation-padding 2))
+            (company-tooltip-annotation-padding 2)
+            (company-tooltip-minimum-width 0))
         (company-pseudo-tooltip-show-at-point (point) 0)
         (let ((ov company-pseudo-tooltip-overlay))
           ;; With margins.
@@ -196,6 +202,7 @@
 
 (ert-deftest company-create-lines-shows-quick-access ()
   (let ((company-show-quick-access t)
+        (company-tooltip-minimum-width 0)
         (company-candidates '("x" "y" "z"))
         (company-candidates-length 3)
         (company-backend 'ignore))
@@ -204,6 +211,7 @@
 
 (ert-deftest company-create-lines-shows-quick-access-on-the-left ()
   (let ((company-show-quick-access 'left)
+        (company-tooltip-minimum-width 0)
         (company-candidates '("x" "y" "z"))
         (company-candidates-length 3)
         (company-backend 'ignore))
@@ -212,6 +220,7 @@
 
 (ert-deftest company-create-lines-combines-quick-access-on-the-left-and-icons ()
   (let ((company-show-quick-access 'left)
+        (company-tooltip-minimum-width 0)
         (company-candidates '("x" "y" "z"))
         (company-format-margin-function (lambda (_candidate _selected)
                                           "X"))
@@ -221,7 +230,8 @@
                    (cdr (company--create-lines 0 999))))))
 
 (ert-deftest company-create-lines-truncates-annotations ()
-  (let* ((ww (company--window-width))
+  (let* ((company-tooltip-maximum-width most-positive-fixnum)
+         (ww (company--window-width))
          (data `(("1" . "(123)")
                  ("2" . nil)
                  ("3" . ,(concat "(" (make-string (- ww 2) ?4) ")"))
@@ -246,7 +256,8 @@
                      (cdr (company--create-lines 0 999)))))))
 
 (ert-deftest company-create-lines-truncates-common-part ()
-  (let* ((ww (company--window-width))
+  (let* ((company-tooltip-maximum-width most-positive-fixnum)
+         (ww (company--window-width))
          (company-candidates-length 2)
          (company-tooltip-margin 1)
          (company-backend #'ignore))
@@ -286,6 +297,7 @@
 (ert-deftest company-create-lines-clears-out-non-printables ()
   :tags '(interactive)
   (let (company-show-quick-access
+        (company-tooltip-minimum-width 0)
         (company-candidates (list
                              (decode-coding-string "avalis\351e" 'utf-8)
                              "avatar"))
@@ -301,13 +313,15 @@
   (let (company-show-quick-access
         (company-candidates '("蛙蛙蛙蛙" "蛙abc"))
         (company-candidates-length 2)
-        (company-backend 'ignore))
+        (company-backend 'ignore)
+        (company-tooltip-minimum-width 0))
     (should (equal '(" 蛙蛙蛙蛙﻿﻿﻿﻿ "
                      " 蛙abc﻿    ")
                    (cdr (company--create-lines 0 999))))))
 
 (ert-deftest company-create-lines-handles-multiple-width-in-annotation ()
   (let* (company-show-quick-access
+         (company-tooltip-minimum-width 0)
          (alist '(("a" . " ︸") ("b" . " ︸︸")))
          (company-candidates (mapcar #'car alist))
          (company-candidates-length 2)
@@ -322,6 +336,7 @@
   :tags '(interactive)
   :expected-result (if (display-graphic-p) :failed :passed)
   (let* (company-show-quick-access
+         (company-tooltip-minimum-width 0)
          (company-candidates '("MIRAI発売1カ月"
                                "MIRAI発売2カ月"))
          (company-candidates-length 2)


### PR DESCRIPTION
Where that doesn't make the experience significantly worse (e.g. flickering).

And change some values which will make the popup resize less often, which is a backup in case some configurations still see flickering on resize.